### PR TITLE
fix: replace deprecated web-vitals APIs

### DIFF
--- a/templates/base/src/reportWebVitals.ts.ejs
+++ b/templates/base/src/reportWebVitals.ts.ejs
@@ -2,12 +2,12 @@
 const reportWebVitals = (onPerfEntry?: () => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(
-      ({ getCLS, getFID, getFCP, getLCP, getTTFB }: any) => {
-        getCLS(onPerfEntry);
-        getFID(onPerfEntry);
-        getFCP(onPerfEntry);
-        getLCP(onPerfEntry);
-        getTTFB(onPerfEntry);
+      ({ onCLS, onFID, onFCP, onLCP, onTTFB }: any) => {
+        onCLS(onPerfEntry);
+        onFID(onPerfEntry);
+        onFCP(onPerfEntry);
+        onLCP(onPerfEntry);
+        onTTFB(onPerfEntry);
       }
     );
   }
@@ -15,12 +15,12 @@ const reportWebVitals = (onPerfEntry?: () => void) => {
 <% } else { %>  
 const reportWebVitals = onPerfEntry => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
+    import('web-vitals').then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+      onCLS(onPerfEntry);
+      onFID(onPerfEntry);
+      onFCP(onPerfEntry);
+      onLCP(onPerfEntry);
+      onTTFB(onPerfEntry);
     });
   }
 };

--- a/templates/base/src/reportWebVitals.ts.ejs
+++ b/templates/base/src/reportWebVitals.ts.ejs
@@ -2,9 +2,9 @@
 const reportWebVitals = (onPerfEntry?: () => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(
-      ({ onCLS, onFID, onFCP, onLCP, onTTFB }: any) => {
+      ({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
         onCLS(onPerfEntry);
-        onFID(onPerfEntry);
+        onINP(onPerfEntry);
         onFCP(onPerfEntry);
         onLCP(onPerfEntry);
         onTTFB(onPerfEntry);
@@ -15,9 +15,9 @@ const reportWebVitals = (onPerfEntry?: () => void) => {
 <% } else { %>  
 const reportWebVitals = onPerfEntry => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+    import('web-vitals').then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
       onCLS(onPerfEntry);
-      onFID(onPerfEntry);
+      onINP(onPerfEntry);
       onFCP(onPerfEntry);
       onLCP(onPerfEntry);
       onTTFB(onPerfEntry);


### PR DESCRIPTION
see https://github.com/GoogleChrome/web-vitals/pull/435 for more info about deprecated `getXYZ` APIs and `onINP`