### PR TITLE
Fix: Replace Start with Router in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create React App for TanStack Router
 
-This CLI applications builds Tanstack Start applications that are the functional equivalent of [Create React App](https://create-react-app.dev/).
+This CLI applications builds Tanstack Router applications that are the functional equivalent of [Create React App](https://create-react-app.dev/).
 
 To help accelerate the migration away from `create-react-app` we created the `create-tsrouter-app` CLI which is a plug-n-play replacement for CRA.
 


### PR DESCRIPTION
The resultant application is a TanStack/Router app not a TanStack/Start app. If the aim is to be functionally equivalent to CRA, shouldn't the documentation reflect the same SPA output.