### PR TITLE
chore: reorder @clack/prompts imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Command, InvalidArgumentError } from 'commander'
-import { intro, outro, spinner, log } from '@clack/prompts'
+import { intro, log, outro, spinner } from '@clack/prompts'
 import { execa } from 'execa'
 import { render } from 'ejs'
 


### PR DESCRIPTION
This PR fixes sort import error.

![image](https://github.com/user-attachments/assets/828669e8-fbf9-4e72-9600-f21c4c1e03ac)
