### PR TITLE
fix: defaults to npm even though bunx is used

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -51,7 +51,7 @@ export async function normalizeOptions(
       projectName: cliOptions.projectName,
       typescript,
       tailwind,
-      packageManager: cliOptions.packageManager || DEFAULT_PACKAGE_MANAGER,
+      packageManager: cliOptions.packageManager || getPackageManager() || DEFAULT_PACKAGE_MANAGER,
       mode: cliOptions.template === 'file-router' ? FILE_ROUTER : CODE_ROUTER,
       git: !!cliOptions.git,
       addOns,

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -8,7 +8,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = [
 export type PackageManager = (typeof SUPPORTED_PACKAGE_MANAGERS)[number]
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'npm'
 
-export function getPackageManager(): PackageManager {
+export function getPackageManager(): PackageManager | undefined {
   const userAgent = process.env.npm_config_user_agent
 
   if (userAgent === undefined) {
@@ -19,5 +19,5 @@ export function getPackageManager(): PackageManager {
     userAgent.startsWith(manager),
   )
 
-  return packageManager || DEFAULT_PACKAGE_MANAGER
+  return packageManager
 }

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -8,7 +8,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = [
 export type PackageManager = (typeof SUPPORTED_PACKAGE_MANAGERS)[number]
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'npm'
 
-export function getPackageManager(): PackageManager | undefined {
+export function getPackageManager(): PackageManager {
   const userAgent = process.env.npm_config_user_agent
 
   if (userAgent === undefined) {


### PR DESCRIPTION
issue that normalizeOptions function defaults to npm when there is no `--package-manger` option  


this fixes issue #15 