### PR TITLE
feat: turn on `autoCodeSplitting` by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 app-*
 my-app
 .DS_Store
+
+.vscode

--- a/templates/react/base/vite.config.js.ejs
+++ b/templates/react/base/vite.config.js.ejs
@@ -10,7 +10,7 @@ import federationConfig from "./module-federation.config.js";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [<% if(fileRouter) { %>TanStackRouterVite(), <% } %>viteReact()<% if (tailwind) { %>, tailwindcss()<% } %><% if (addOnEnabled['module-federation']) { %>, federation(federationConfig)<% } %>],
+  plugins: [<% if(fileRouter) { %>TanStackRouterVite({ autoCodeSplitting: true }), <% } %>viteReact()<% if (tailwind) { %>, tailwindcss()<% } %><% if (addOnEnabled['module-federation']) { %>, federation(federationConfig)<% } %>],
   test: {
     globals: true,
     environment: "jsdom",

--- a/templates/solid/base/vite.config.js.ejs
+++ b/templates/solid/base/vite.config.js.ejs
@@ -10,7 +10,7 @@ import federationConfig from "./module-federation.config.js";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [<% if (addOnEnabled['module-federation']) { %>federation(federationConfig), <% } %><%if (fileRouter) { %>
-    TanStackRouterVite({ target: 'solid' }),<% } %>
+    TanStackRouterVite({ target: 'solid', autoCodeSplitting: true }),<% } %>
     solidPlugin(),
     tailwindcss(),
   ],<% if (addOnEnabled['solid-ui']) { %>


### PR DESCRIPTION
Duplicating the work from https://github.com/TanStack/create-tsrouter-app/pull/19, so that it's in the `alpha` branch as well.
Also, make the necessary changes for this to be turned on in the Solid base.