### PR TITLE
fix(template/start): correct router type declaration with typeof

### DIFF
--- a/templates/react/add-on/start/assets/src/router.tsx.ejs
+++ b/templates/react/add-on/start/assets/src/router.tsx.ejs
@@ -46,6 +46,6 @@ const router = createRouter()
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
   interface Register {
-    router: router
+    router: typeof router
   }
 }


### PR DESCRIPTION
this simple PR addresses an error in the `create-tsrouter-app` with Start add-on template. Particularly:

```
const router = createRouter()

// Register the router instance for type safety
declare module '@tanstack/react-router' {
  interface Register {
    router: router // Error: 'router' refers to a value, but is being used as a type here.
  }
}
```

the fix is to use `typeof router` to correctly reference the *type* of the router instance