### PR TITLE
fix: add devtools for solid, like react has

### DIFF
--- a/templates/solid/base/README.md.ejs
+++ b/templates/solid/base/README.md.ejs
@@ -132,7 +132,7 @@ Here is an example layout that includes a header:
 
 ```tsx
 import { Outlet, createRootRoute } from '@tanstack/solid-router'
-import { TanStackRouterDevtools } from '@tanstack/router-devtools'
+import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'
 
 import { Link } from "@tanstack/solid-router";
 

--- a/templates/solid/base/package.json
+++ b/templates/solid/base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.110.0",
-    "@tanstack/router-devtools": "^1.109.2",
+    "@tanstack/solid-router-devtools": "^1.109.2",
     "@tanstack/router-plugin": "^1.109.2",
     "solid-js": "^1.9.4"
   },

--- a/templates/solid/code-router/src/main.tsx.ejs
+++ b/templates/solid/code-router/src/main.tsx.ejs
@@ -5,7 +5,7 @@ import {
   createRoute,
   createRouter,
 } from "@tanstack/solid-router";
-// import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import { TanStackRouterDevtools } from "@tanstack/solid-router-devtools";
 import { render } from 'solid-js/web'
 <% for(const route of routes) { %>import <%= route.name %> from "<%= route.path %>";
 <% } %><% if (routes.length > 0) { %>
@@ -26,7 +26,7 @@ const rootRoute = createRootRoute({
     <% } %>
       <% if (routes.length > 0) { %><Header /><% } %>
       <Outlet />
-      {/* <TanStackRouterDevtools /> */}
+      <TanStackRouterDevtools />
       <% for(const integration of integrations.filter(i => i.type === 'layout')) { %>
         <<%= integration.name %> />
       <% } %>

--- a/templates/solid/file-router/src/routes/__root.tsx.ejs
+++ b/templates/solid/file-router/src/routes/__root.tsx.ejs
@@ -1,5 +1,5 @@
 import { Outlet, createRootRouteWithContext } from '@tanstack/solid-router'
-// import { TanStackRouterDevtools } from '@tanstack/router-devtools'<% for(const integration of integrations.filter(i => i.type === 'layout' || i.type === 'provider')) { %>
+import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'<% for(const integration of integrations.filter(i => i.type === 'layout' || i.type === 'provider')) { %>
 import <%= integration.name %> from "../<%= integration.path %>";
 <% } %>
 <% if (addOnEnabled['solid-ui']) { %>


### PR DESCRIPTION
the `@tanstack/router-devtools` is react-only, which is why it was disabled for solid.

The new `@tanstack/solid-router-devtools` will work, so I've enabled it to be like the react starters

I've tested locally that this installs correctly