### PR TITLE
fix: implement handling of addon-specific .gitignore entries

### DIFF
--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -653,6 +653,24 @@ export async function createApp(
     resolve(targetDir, '.gitignore'),
   )
 
+  // Append addon-specific .gitignore entries
+  for (const addOn of options.chosenAddOns) {
+    if (
+      environment.exists(
+        resolve(addOn.directory, 'assets', '_dot_gitignore.append'),
+      )
+    ) {
+      await environment.appendFile(
+        resolve(targetDir, '.gitignore'),
+        (
+          await environment.readFile(
+            resolve(addOn.directory, 'assets', '_dot_gitignore.append'),
+          )
+        ).toString(),
+      )
+    }
+  }
+
   // Create the README.md
   await templateFile(templateDirBase, 'README.md.ejs')
 

--- a/templates/react/add-on/start/assets/_dot_gitignore.append
+++ b/templates/react/add-on/start/assets/_dot_gitignore.append
@@ -1,0 +1,2 @@
+.output
+.vinxi

--- a/templates/react/base/_dot_gitignore
+++ b/templates/react/base/_dot_gitignore
@@ -3,5 +3,3 @@ node_modules
 dist
 dist-ssr
 *.local
-.output
-.vinxi


### PR DESCRIPTION
Related to https://github.com/TanStack/create-tsrouter-app/pull/53/commits/471e667d419c3d7cfb1fc48a27adf1026bfabe24, this implements the ability to handle addon-specific `_dot_gitignore.append` files.

As a particular usage scenario, I've moved `.output` and `.vinxi` from the global `_dot_gitignore` to a start-specific `_dot_gitignore.append` file.