### PR TITLE
fix: correct spelling of "Anthropic" in TanStack Chat description

### DIFF
--- a/templates/solid/example/tanchat/info.json
+++ b/templates/solid/example/tanchat/info.json
@@ -1,6 +1,6 @@
 {
   "name": "TanStack Chat",
-  "description": "A chat example that uses TanStack Start and TanStack Store. Features chat with Antrhopic Sonnet, chat history and custom prompts.",
+  "description": "A chat example that uses TanStack Start and TanStack Store. Features chat with Anthropic Sonnet, chat history and custom prompts.",
   "phase": "example",
   "templates": ["file-router"],
   "link": "",


### PR DESCRIPTION
Updated the TanStack Chat example description to correctly reference "Anthropic" instead of "Antrhopic".