### PR TITLE
fix: normalize addOns argument for Windows PowerShell/Command Prompt …

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -23,6 +23,15 @@ import type { CliOptions, Options } from './types.js'
 export async function normalizeOptions(
   cliOptions: CliOptions,
 ): Promise<Required<Options> | undefined> {
+  // in some cases, if you use windows/powershell, the argument for addons
+  // if sepparated by comma is not really passed as an array, but as a string 
+  // with spaces, We need to normalize this edge case.
+  if (Array.isArray(cliOptions.addOns) && cliOptions.addOns.length === 1) {
+      const parseSeparatedArgs = cliOptions.addOns[0].split(' ');
+      if (parseSeparatedArgs.length > 1) {
+          cliOptions.addOns = parseSeparatedArgs;
+      }
+  }
   if (cliOptions.projectName) {
     let typescript =
       cliOptions.template === 'typescript' ||


### PR DESCRIPTION
This pull request proposes the following work:

- it was detected that, in windows machines using PowerShell/Command Prompt, the arguments passed on the addOns argument was passed as a string with spaces, rather than an array.

| Before | After |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/dfc52d17-5b08-41d3-86b5-a82e927c0aac)|![image](https://github.com/user-attachments/assets/2f7c66f7-a6f4-40fa-bb40-c11c06e6406f)|

However, this doesn't address the bug on #64 of TanStack forms not finishing its setup.
