### PR TITLE
chore(deps): update shadcn CLI from `@canary` to `@latest`

### DIFF
--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -487,7 +487,7 @@ export async function createApp(
       )
       await environment.execute(
         'npx',
-        ['shadcn@canary', 'add', '--silent', '--yes', ...shadcnComponents],
+        ['shadcn@latest', 'add', '--silent', '--yes', ...shadcnComponents],
         resolve(targetDir),
       )
       s?.stop(`Installed additional shadcn components`)

--- a/templates/react/add-on/shadcn/README.md
+++ b/templates/react/add-on/shadcn/README.md
@@ -1,7 +1,7 @@
 ## Shadcn
 
-Add components using the canary version of [Shadcn](https://ui.shadcn.com/).
+Add components using the latest version of [Shadcn](https://ui.shadcn.com/).
 
 ```bash
-pnpx shadcn@canary add button
+pnpx shadcn@latest add button
 ```

--- a/templates/react/add-on/shadcn/assets/_dot_cursorrules.append
+++ b/templates/react/add-on/shadcn/assets/_dot_cursorrules.append
@@ -1,7 +1,7 @@
 # shadcn instructions
 
-Use the canary version of Shadcn to install new components, like this command to add a button component:
+Use the latest version of Shadcn to install new components, like this command to add a button component:
 
 ```bash
-pnpx shadcn@canary add button
+pnpx shadcn@latest add button
 ```


### PR DESCRIPTION
The shadcn CLI has now shipped Tailwind v4 as `@latest`. This PR updates the shadcn command used to install components to be:

```shell
shadcn@latest add --silent --yes {...shadcnComponents}
```

instead of:

```shell
shadcn@canary add --silent --yes {...shadcnComponents}
```
