### PR TITLE
Chore: Use template literal to comply with Biome linter

### DIFF
--- a/packages/cta-engine/templates/react/add-on/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/cta-engine/templates/react/add-on/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -13,7 +13,7 @@ function getUrl() {
     if (typeof window !== "undefined") return "";
     return `http://localhost:${process.env.PORT ?? 3000}`;
   })();
-  return base + "/api/trpc";
+  return `${base}/api/trpc`;
 }
 
 export const trpcClient = createTRPCClient<TRPCRouter>({


### PR DESCRIPTION
Switched to template literals to comply with Biome linting rules. Fixes an issue where scaffold initialization would "fail" when selecting TanStack Query and tRPC with the Biome toolchain.

<details>
<summary>Output with this problem</summary>
<img width="907" alt="image" src="https://github.com/user-attachments/assets/794eb0b4-a5bd-4fa6-ba07-e2ac5b11e08a" />
</details>