### PR TITLE
chore: remove biome as default html formatter

### DIFF
--- a/packages/cta-engine/templates/react/base/_dot_vscode/settings.biome.json
+++ b/packages/cta-engine/templates/react/base/_dot_vscode/settings.biome.json
@@ -26,9 +26,6 @@
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[html]": {
-    "editor.defaultFormatter": "biomejs.biome"
-  },
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },

--- a/packages/cta-engine/templates/solid/base/_dot_vscode/settings.biome.json
+++ b/packages/cta-engine/templates/solid/base/_dot_vscode/settings.biome.json
@@ -26,9 +26,6 @@
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "[html]": {
-    "editor.defaultFormatter": "biomejs.biome"
-  },
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },


### PR DESCRIPTION
Biome cannot format HTML

![image](https://github.com/user-attachments/assets/2da086d6-8019-4424-bfcf-d2943dd32843)
