### PR TITLE
chore: remove unnecessary white space from readme

### DIFF
--- a/packages/cta-engine/templates/react/base/README.md.ejs
+++ b/packages/cta-engine/templates/react/base/README.md.ejs
@@ -1,4 +1,4 @@
-Welcome to your new TanStack app! 
+Welcome to your new TanStack app!
 
 # Getting Started
 
@@ -6,7 +6,7 @@ To run this application:
 
 ```bash
 <%= packageManager %> install
-<%= getPackageManagerRunScript('start') %>  
+<%= getPackageManagerRunScript('start') %>
 ```
 
 # Building For Production


### PR DESCRIPTION
README template for React has some unnecessary white spaces at the end of sentence.

This PR removes these spaces.