### PR TITLE
Feat/tailwind prompt

### DIFF
--- a/packages/cta-engine/src/create-app.ts
+++ b/packages/cta-engine/src/create-app.ts
@@ -788,6 +788,8 @@ ${environment.getErrors().join('\n')}`
 
     outro(`Your ${appName} app is ready in '${basename(targetDir)}'.
 
+${options.tailwind ? 'Tailwind CSS has been installed' : ''}
+
 Use the following commands to start your app:
 % cd ${options.projectName}
 % ${startCommand}

--- a/packages/cta-engine/src/options.ts
+++ b/packages/cta-engine/src/options.ts
@@ -248,21 +248,6 @@ export async function promptForOptions(
     }
   }
 
-  // Tailwind selection
-  if (!cliOptions.tailwind && options.framework === 'react') {
-    const tailwind = await confirm({
-      message: 'Would you like to use Tailwind CSS?',
-      initialValue: true,
-    })
-    if (isCancel(tailwind)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
-    options.tailwind = tailwind
-  } else {
-    options.tailwind = options.framework === 'solid' || !!cliOptions.tailwind
-  }
-
   // Package manager selection
   if (cliOptions.packageManager === undefined) {
     const detectedPackageManager = getPackageManager()
@@ -382,6 +367,28 @@ export async function promptForOptions(
       options.mode,
       forcedAddOns,
     )
+  }
+
+  // Tailwind selection
+  if (
+    !cliOptions.tailwind &&
+    !options.tailwind &&
+    options.framework === 'react'
+  ) {
+    const tailwind = await confirm({
+      message: 'Would you like to use Tailwind CSS?',
+      initialValue: true,
+    })
+    if (isCancel(tailwind)) {
+      cancel('Operation cancelled.')
+      process.exit(0)
+    }
+    options.tailwind = tailwind
+  } else {
+    options.tailwind =
+      options.framework === 'solid' ||
+      !!cliOptions.tailwind ||
+      !!options.tailwind
   }
 
   // Collect variables


### PR DESCRIPTION
- The prompt asking whether to install Tailwind CSS is now skipped if one or more previously selected options require it.
- A console notice is displayed to inform the user when Tailwind is being installed.

Related to #85 