### PR TITLE
fix: wrong github link on npm for create-start-app

### DIFF
--- a/cli/create-start-app/package.json
+++ b/cli/create-start-app/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TanStack/create-router-app.git"
+    "url": "https://github.com/TanStack/create-tsrouter-app.git"
   },
   "homepage": "https://tanstack.com/router",
   "funding": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/be7dbaef-f202-4aa2-b87c-a8126e4c3634)
