### PR TITLE
Consolidates all mcp tools to take frameworks as arguments

### DIFF
--- a/frameworks/react-cra/src/index.ts
+++ b/frameworks/react-cra/src/index.ts
@@ -24,7 +24,7 @@ export function createFrameworkDefinition(): FrameworkDefinition {
 
   return {
     id: 'react-cra',
-    name: 'react',
+    name: 'React',
     description: 'Templates for React CRA',
     version: '0.1.0',
     base: files,

--- a/frameworks/solid/src/index.ts
+++ b/frameworks/solid/src/index.ts
@@ -24,7 +24,7 @@ export function createFrameworkDefinition(): FrameworkDefinition {
 
   return {
     id: 'solid',
-    name: 'solid',
+    name: 'Solid',
     description: 'Solid templates for Tanstack Router Applications',
     version: '0.1.0',
     base: files,


### PR DESCRIPTION
This PR makes the MCP tools work across frameworks, reducing the number of tools an agent needs to create Tanstack applications. This is important because Agents work better with 5-6 tools. (Two for every JS framework isn't ideal!)
![image](https://github.com/user-attachments/assets/9950a47c-d388-4c16-8524-3573488f4f17)

Closes #101