### PR TITLE
add Vite-Plugin to Neon add-on

### DIFF
--- a/frameworks/react-cra/add-ons/neon/README.md
+++ b/frameworks/react-cra/add-ons/neon/README.md
@@ -1,3 +1,8 @@
 ## Setting up Neon
 
-- Set the `DATABASE_URL` in your `.env`.
+When running the `dev` command, the `@neondatabase/vite-plugin-postgres` will identify there is not a database setup. It will then create and seed a claimable database.
+
+It is the same process as [Neon Launchpad](https://neon.new).
+
+> [!IMPORTANT]  
+> Claimable databases expire in 72 hours.

--- a/frameworks/react-cra/add-ons/neon/assets/_dot_env.example.append
+++ b/frameworks/react-cra/add-ons/neon/assets/_dot_env.example.append
@@ -1,0 +1,3 @@
+# These will be automatically created by Neon Launchpad (https://neon.new).
+DATABASE_URL=
+DATABASE_URL_POOLER=

--- a/frameworks/react-cra/add-ons/neon/assets/_dot_env.local.append
+++ b/frameworks/react-cra/add-ons/neon/assets/_dot_env.local.append
@@ -1,2 +1,0 @@
-# Neon database URL
-DATABASE_URL=

--- a/frameworks/react-cra/add-ons/neon/info.json
+++ b/frameworks/react-cra/add-ons/neon/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Neon",
   "description": "Add the Neon database to your application.",
-  "link": "https://neon.tech",
+  "link": "https://neon.com",
   "phase": "add-on",
   "type": "add-on",
   "modes": ["file-router"],

--- a/frameworks/react-cra/add-ons/neon/package.json
+++ b/frameworks/react-cra/add-ons/neon/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@neondatabase/serverless": "^1.0.0"
+    "@neondatabase/serverless": "^1.0.0",
+    "@neondatabase/vite-plugin-postgres": "^0.2.0"
   }
 }

--- a/frameworks/react-cra/add-ons/start/assets/vite.config.ts.ejs
+++ b/frameworks/react-cra/add-ons/start/assets/vite.config.ts.ejs
@@ -4,9 +4,20 @@ import viteTsConfigPaths from 'vite-tsconfig-paths'<% if (tailwind) { %>
 import tailwindcss from "@tailwindcss/vite"
 <% } %><% if (addOnEnabled.sentry) { %>
 import { wrapVinxiConfigWithSentry } from "@sentry/tanstackstart-react";
+<% } %><% if (addOnEnabled.neon) { %>
+import postgresPlugin from "@neondatabase/vite-plugin-postgres";
 <% } %>
 const config = defineConfig({
     plugins: [
+      <% if (addOnEnabled.neon) { %>
+        postgresPlugin({
+          seed: {
+            type: "sql-script",
+            path: "db/init.sql"
+          },
+          referrer: 'create-tanstack'
+        }),
+      <% } %>
       // this is the plugin that enables path aliases
       viteTsConfigPaths({
         projects: ['./tsconfig.json'],


### PR DESCRIPTION
This PR adds the Vite Plugin from [Neon Launchpad](https://neon.new). It enables the template to automatically create and seed a database without the user having a Neon account. This way everything is immediately functional.