### PR TITLE
fix: use bun instead of bunx to run scripts. [⚠️ Potentially dangerous]

### DIFF
--- a/packages/cta-engine/src/package-manager.ts
+++ b/packages/cta-engine/src/package-manager.ts
@@ -34,7 +34,7 @@ export function getPackageManagerScriptCommand(
     case 'pnpm':
       return { command: 'pnpm', args: [...args] }
     case 'bun':
-      return { command: 'bunx', args: ['--bun', 'run', ...args] }
+      return { command: 'bun', args: ['--bun', 'run', ...args] }
     case 'deno':
       return { command: 'deno', args: ['task', ...args] }
     default:

--- a/packages/cta-engine/tests/package-manager.test.ts
+++ b/packages/cta-engine/tests/package-manager.test.ts
@@ -20,7 +20,7 @@ describe('getPackageManagerScriptCommand', () => {
   })
   it('bun', () => {
     expect(formatCommand(getPackageManagerScriptCommand('bun', ['dev']))).toBe(
-      'bunx --bun run dev',
+      'bun --bun run dev',
     )
   })
   it('deno', () => {


### PR DESCRIPTION
`bunx` is an alias for `bun x`, to execute binaries. [Docs](https://bun.sh/docs/cli/bunx)

> [!CAUTION]
> The suggested `bunx --bun run dev` would download and execute the `run` package ([link](https://www.npmjs.com/package/run)). Finger-crossed it is not malicious.

This is the current, wrong, output

```sh
> bun create start-app@latest
┌  Let's configure your TanStack Start application
│
◇  What would you like to name your project?
│  my-app
│
◇  Would you like to use Tailwind CSS?
│  Yes
│
◇  Select toolchain
│  Biome
│
◇  What add-ons would you like for your project?
│  none
│
◇  Would you like any examples?
│  none
│
◇  Initialized git repository
│
◇  Installed dependencies
│
▲  Warnings: 
│  TanStack Start is not yet at 1.0 and may change significantly or not be compatible with other add-ons.
│  Migrating to Start might require deleting node_modules and re-installing.
│
└  Your TanStack Start app is ready in 'tanstack-start-rc-tutorial'.

Use the following commands to start your app:
% cd tanstack-start-rc-tutorial
% bunx --bun run dev

Please read README.md for information on testing, styling, adding routes, etc.
```