### PR TITLE
Exclude styles.css from biome.json

### DIFF
--- a/frameworks/react-cra/toolchains/biome/assets/biome.json
+++ b/frameworks/react-cra/toolchains/biome/assets/biome.json
@@ -12,7 +12,8 @@
 			"**/.vscode/**/*",
 			"**/index.html",
 			"**/vite.config.js",
-			"!**/src/routeTree.gen.ts"
+			"!**/src/routeTree.gen.ts",
+			"!**/src/styles.css"
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
## Summary
- ignore `src/styles.css` in Biome lint config so the linter stops flagging the tailwind-specific `@custom-variant`, `@apply`, and `@theme` directives
