### PR TITLE
fix(solid): vite config template missing newline

### DIFF
--- a/frameworks/solid/project/base/vite.config.ts.ejs
+++ b/frameworks/solid/project/base/vite.config.ts.ejs
@@ -5,7 +5,8 @@ import tailwindcss from '@tailwindcss/vite'<% if (addOnEnabled['solid-ui']) { %>
 import { resolve } from 'node:path'<% } %><% if (addOnEnabled['module-federation']) { %>
 import {federation} from "@module-federation/vite";<% } %><% if (addOnEnabled['module-federation']) { %>
 import federationConfig from "./module-federation.config.js";
-<% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportContent(integration) %>
+<% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %>
+<%- integrationImportContent(integration) %>
 <% } %>
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
fixes #196

we're not using `;` so missing newline causes it to have invalid syntax