### PR TITLE
fix: update cloudflare's `wrangler.json` to `wrangler.jsonc`

### DIFF
--- a/frameworks/react-cra/hosts/cloudflare/assets/wrangler.jsonc
+++ b/frameworks/react-cra/hosts/cloudflare/assets/wrangler.jsonc
@@ -3,8 +3,5 @@
   "name": "tanstack-start-app",
   "compatibility_date": "2025-09-02",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
-  "vars": {
-    "MY_VAR": "Hello from Cloudflare"
-  }
+  "main": "@tanstack/react-start/server-entry"
 }


### PR DESCRIPTION
Cloudflare recommends using a jsonc file instead of a json one

This is also relevant here since we want to enable the [create-cloudflare CLI (C3)](https://developers.cloudflare.com/pages/get-started/c3/) to create tanstack start application (by calling the tanstack cli) and C3 appends comments to wrangler configuration files, meaning that these will show up as erroneous if a json file is used instead of jsonc