### PR TITLE
fix: handle drizzle + better-sqlite3 driver error caused by DATABASE_URL prefix

### DIFF
--- a/frameworks/react-cra/add-ons/drizzle/assets/_dot_env.local.append.ejs
+++ b/frameworks/react-cra/add-ons/drizzle/assets/_dot_env.local.append.ejs
@@ -4,4 +4,4 @@ DATABASE_URL="postgresql://username:password@localhost:5432/mydb"<% } else if (a
 # Database URL for MySQL
 DATABASE_URL="mysql://username:password@localhost:3306/mydb"<% } else if (addOnOption.drizzle.database === 'sqlite') { %>
 # Database URL for SQLite
-DATABASE_URL="file:./dev.db"<% } %>
+DATABASE_URL="dev.db"<% } %>

--- a/frameworks/react-cra/src/checksum.ts
+++ b/frameworks/react-cra/src/checksum.ts
@@ -1,3 +1,3 @@
 // This file is auto-generated. Do not edit manually.
 // Generated from add-ons, examples, hosts, project, and toolchains directories
-export const contentChecksum = '2bc5d6d1275fc866a1561719c657003610a9c50e837678758f63632b4eea34a0'
+export const contentChecksum = '5e28990850f8cfa59f2d4c9f4365968422deb2a849d6915134fc10b1417fa096'


### PR DESCRIPTION
When using the `create @tanstack/start@latest` command, the generated TanStack Start app fails to initialize when using the drizzle + sqlite add-on with the following error:

  `Cannot open database because the directory does not exist`

This happens because the generated `DATABASE_URL` is set to `file:./dev.db`, but the better-sqlite3 driver
does not support the `file:` prefix. This commit removes that prefix and sets `DATABASE_URL` to `dev.db`
to ensure the app starts correctly.

This change is in line with [Drizzle's latest documentation for using better-sqlite3](https://orm.drizzle.team/docs/get-started-sqlite#step-2---initialize-the-driver-and-make-a-query).

