### PR TITLE
fix(package-manager): fix command `pnpx` to `pnpm dlx`

### DIFF
--- a/packages/cta-engine/src/package-manager.ts
+++ b/packages/cta-engine/src/package-manager.ts
@@ -51,7 +51,7 @@ export function getPackageManagerExecuteCommand(
     case 'yarn':
       return { command: 'yarn', args: ['dlx', pkg, ...args] }
     case 'pnpm':
-      return { command: 'pnpx', args: [pkg, ...args] }
+      return { command: 'pnpm', args: ['dlx', pkg, ...args] }
     case 'bun':
       return { command: 'bunx', args: ['--bun', pkg, ...args] }
     case 'deno':

--- a/packages/cta-engine/tests/integrations/shadcn.test.ts
+++ b/packages/cta-engine/tests/integrations/shadcn.test.ts
@@ -52,8 +52,16 @@ describe('shadcn', () => {
 
     expect(output.commands).toEqual([
       {
-        command: 'pnpx',
-        args: ['shadcn@latest', 'add', '--silent', '--yes', 'button', 'card'],
+        command: 'pnpm',
+        args: [
+          'dlx',
+          'shadcn@latest',
+          'add',
+          '--silent',
+          '--yes',
+          'button',
+          'card',
+        ],
       },
     ])
   })
@@ -83,8 +91,16 @@ describe('shadcn', () => {
 
     expect(output.commands).toEqual([
       {
-        command: 'pnpx',
-        args: ['shadcn@latest', 'add', '--silent', '--yes', 'button', 'card'],
+        command: 'pnpm',
+        args: [
+          'dlx',
+          'shadcn@latest',
+          'add',
+          '--silent',
+          '--yes',
+          'button',
+          'card',
+        ],
       },
     ])
   })

--- a/packages/cta-engine/tests/package-manager.test.ts
+++ b/packages/cta-engine/tests/package-manager.test.ts
@@ -48,7 +48,7 @@ describe('getPackageManagerExecuteCommand', () => {
       formatCommand(
         getPackageManagerExecuteCommand('pnpm', 'shadcn', ['add', 'button']),
       ),
-    ).toBe('pnpx shadcn add button')
+    ).toBe('pnpm dlx shadcn add button')
   })
   it('bun', () => {
     expect(


### PR DESCRIPTION
Thank you for providing such a convenient tool

An error occurred because the command used `pnpx`.
Since `pnpm dlx` is now recommended over `pnpx`, I replaced it accordingly.

References:

https://github.com/orgs/pnpm/discussions/6477

https://pnpm.io/cli/dlx