### PR TITLE
fix: correct `experimental_createMCPClient` import and typo in tanchat

### DIFF
--- a/frameworks/react-cra/examples/tanchat/assets/src/utils/demo.tools.ts
+++ b/frameworks/react-cra/examples/tanchat/assets/src/utils/demo.tools.ts
@@ -1,5 +1,6 @@
-import { experimental_createMCPClient, tool } from 'ai'
-//import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { tool } from 'ai'
+// import { experimental_createMCPClient } from '@ai-sdk/mcp'
+// import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { z } from 'zod'
 
 import guitars from '../data/example-guitars'
@@ -44,7 +45,7 @@ const recommendGuitar = tool({
 })
 
 export default async function getTools() {
-  // const mcpTools = await mcpCient.tools()
+  // const mcpTools = await mcpClient.tools()
   return {
     // ...mcpTools,
     getGuitars,

--- a/frameworks/react-cra/examples/tanchat/package.json
+++ b/frameworks/react-cra/examples/tanchat/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.1",
+    "@ai-sdk/mcp": "^0.0.5",
     "@ai-sdk/react": "^2.0.8",
     "@modelcontextprotocol/sdk": "^1.8.0",
     "ai": "^5.0.8",


### PR DESCRIPTION
- Fix `experimental_createMCPClient` import path (`ai` -> `@ai-sdk/mcp`)
  - https://ai-sdk.dev/docs/reference/ai-sdk-core/create-mcp-client#import
- Fix typo: `mcpCient` → `mcpClient`
- Add `@ai-sdk/mcp` dependency