### PR TITLE
feat(cli): add keyboard shortcuts help to multiselect prompts

### DIFF
--- a/packages/cta-cli/src/ui-prompts.ts
+++ b/packages/cta-cli/src/ui-prompts.ts
@@ -3,6 +3,7 @@ import {
   confirm,
   isCancel,
   multiselect,
+  note,
   select,
   text,
 } from '@clack/prompts'
@@ -103,6 +104,9 @@ export async function selectPackageManager(): Promise<PackageManager> {
   return packageManager
 }
 
+// Track if we've shown the multiselect help text
+let hasShownMultiselectHelp = false
+
 export async function selectAddOns(
   framework: Framework,
   mode: string,
@@ -114,6 +118,12 @@ export async function selectAddOns(
   const addOns = allAddOns.filter((addOn) => addOn.type === type)
   if (addOns.length === 0) {
     return []
+  }
+
+  // Show help text only once
+  if (!hasShownMultiselectHelp) {
+    note('Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm', 'Keyboard Shortcuts')
+    hasShownMultiselectHelp = true
   }
 
   const value = await multiselect({

--- a/packages/cta-cli/tests/ui-prompts.test.ts
+++ b/packages/cta-cli/tests/ui-prompts.test.ts
@@ -93,7 +93,8 @@ describe('selectPackageManager', () => {
 })
 
 describe('selectAddOns', () => {
-  it('should select some add-ons', async () => {
+  it('should show keyboard shortcuts help and select add-ons', async () => {
+    const noteSpy = vi.spyOn(clack, 'note').mockImplementation(() => {})
     vi.spyOn(clack, 'multiselect').mockImplementation(async () => ['add-on-1'])
     vi.spyOn(clack, 'isCancel').mockImplementation(() => false)
 
@@ -114,7 +115,12 @@ describe('selectAddOns', () => {
       'add-on',
       'Select add-ons',
     )
+
     expect(packageManager).toEqual(['add-on-1'])
+    expect(noteSpy).toHaveBeenCalledWith(
+      'Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm',
+      'Keyboard Shortcuts',
+    )
   })
 
   it('should exit on cancel', async () => {


### PR DESCRIPTION
Hey 👋 

While using the cli starter,  I kinda struggled to use the multiselect for the addons ( maybe skill issue on my side  😅 ) .
This pr adds a note before showing the multiselect .

- Add note() before first multiselect to show keyboard shortcuts
- Help text: Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm
- Show help only once to avoid cluttering the interface
- Add unit test to verify note() is called with correct message

Improves UX by helping users understand multiselect navigation