### PR TITLE
feat(minor): Change SERVER_URL validation to use z.url()

### DIFF
--- a/frameworks/solid/add-ons/t3env/assets/src/env.ts
+++ b/frameworks/solid/add-ons/t3env/assets/src/env.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
  
 export const env = createEnv({
   server: {
-    SERVER_URL: z.string().url().optional(),
+    SERVER_URL: z.url().optional(),
   },
  
   /**


### PR DESCRIPTION
In the latest version of Zod (>4), `z.string().url()` is deprecated in favour of `z.url()`