### PR TITLE
fix: remove trailing comma from tsconfig.json template

### DIFF
--- a/frameworks/react-cra/project/base/tsconfig.json.ejs
+++ b/frameworks/react-cra/project/base/tsconfig.json.ejs
@@ -23,7 +23,7 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
### Summary
Fix an invalid trailing comma in `tsconfig.json.ejs` inside the CRA template.

### Details
While reviewing the template files, I found that the CRA version of
`tsconfig.json.ejs` contains a trailing comma inside the `paths` field,
which makes the resulting JSON invalid.

### Note
The CRA template is currently registered in the CLI codebase,  
but it does not appear as a selectable template option  
(`typescript`, `javascript`, and `file-router` are the only active options).  
Because of this, the CRA template is not used during project generation,
so I wasn’t able to validate the fix through a generated project.

Still, the template file itself contains a clear JSON syntax issue,
so this PR removes the trailing comma.

### Changes
- Remove trailing comma from `paths` in `tsconfig.json.ejs`.

Thanks!
