### PR TITLE
Remove @tanstack/db from the db add-on template's dependencies.

### DIFF
--- a/frameworks/react-cra/add-ons/db/package.json
+++ b/frameworks/react-cra/add-ons/db/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@tanstack/db": "^0.4.3",
     "@tanstack/query-db-collection": "^0.2.0",
     "@tanstack/react-db": "^0.1.1",
     "zod": "^4.0.14"


### PR DESCRIPTION
## Issue

When using the Start CLI with the `@tanstack/db` add-on, we end up with redundant dependencies:

- `@tanstack/db` - Base JavaScript library
- `@tanstack/react-db` - React wrapper (which depends on `@tanstack/db`)

This creates a duplicate dependency problem where both packages are listed as direct dependencies, causing TypeScript type conflicts between identical types from different `node_modules` paths.

### Dependency Analysis

```bash
bun why @tanstack/react-db

@tanstack/react-db@0.1.49
  └─ . (requires ^0.1.49)
```

```bash
bun why @tanstack/db

@tanstack/db@0.5.5
  ├─ @tanstack/electric-db-collection@0.2.5 (requires 0.5.5)
  │  └─ . (requires ^0.2.5)
  ├─ @tanstack/react-db@0.1.49 (requires 0.5.5)
  │  └─ . (requires ^0.1.49)
  ├─ . (requires ^0.5.5)
  └─ peer @tanstack/query-db-collection@1.0.4 (requires *)
     └─ . (requires ^1.0.4)
```

As shown above, `@tanstack/react-db` already requires `@tanstack/db` as a dependency. The CLI is adding both packages directly to `package.json`, which causes TypeScript to see them as separate types from different paths.

## Solution

Remove `@tanstack/db` from the db add-on template's direct dependencies. `@tanstack/react-db` will transitively provide `@tanstack/db`, avoiding duplication and type conflicts.

### What This Changes

**Before:**
```json
{
  "dependencies": {
    "@tanstack/db": "^0.5.5",
    "@tanstack/query-db-collection": "^0.2.0",
    "@tanstack/react-db": "^0.1.1",
    "zod": "^4.0.14"
  }
}
```

**After:**
```json
{
  "dependencies": {
    "@tanstack/query-db-collection": "^0.2.0",
    "@tanstack/react-db": "^0.1.1",
    "zod": "^4.0.14"
  }
}
```

This ensures only one copy of `@tanstack/db` exists in the dependency tree, eliminating the TypeScript type conflicts.
