### PR TITLE
use `preview` for `vite preview`

### DIFF
--- a/examples/react-cra/blog-starter/package.json
+++ b/examples/react-cra/blog-starter/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/examples/react-cra/ecommerce-starter/package.json
+++ b/examples/react-cra/ecommerce-starter/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/examples/react-cra/legend-state-add-on/package.json
+++ b/examples/react-cra/legend-state-add-on/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build && tsc",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/examples/react-cra/mui-add-on/package.json
+++ b/examples/react-cra/mui-add-on/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build && tsc",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/examples/react-cra/resume-starter/package.json
+++ b/examples/react-cra/resume-starter/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/frameworks/react-cra/project/base/package.json
+++ b/frameworks/react-cra/project/base/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build && tsc",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {

--- a/frameworks/solid/project/base/package.json
+++ b/frameworks/solid/project/base/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build && tsc",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
There are just a few reserved `vite <commands>`, namely:

vite serve -> vite
vite dev -> vite
vite preview
vite build
vite optimize (deprecated)

Because `vite serve` -> `vite` (dev server), it's more clear to use `preview` when referring to `vite preview` (previewing the prod build). All docs examples of tanstack router and start already follow this convention.