### PR TITLE
fix: sentry env variable missing in node context

### DIFF
--- a/frameworks/react-cra/add-ons/sentry/assets/instrument.server.mjs
+++ b/frameworks/react-cra/add-ons/sentry/assets/instrument.server.mjs
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/tanstackstart-react'
 Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
+  dsn: process.env.VITE_SENTRY_DSN,
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#sendDefaultPii
   sendDefaultPii: true,


### PR DESCRIPTION
`import.meta.env` is only available in Vite context, not the Node server context.

This change fixes that.

Example:
```
> NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000

file:///Users/duane/Projects/myproject/instrument.server.mjs:3
  dsn: import.meta.env.VITE_SENTRY_DSN,
                       ^

TypeError: Cannot read properties of undefined (reading 'VITE_SENTRY_DSN')
    at file:///Users/duane/Projects/myproject/instrument.server.mjs:3:24
    at ModuleJob.run (node:internal/modules/esm/module_job:377:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:671:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:96:9)

Node.js v24.11.1
 ELIFECYCLE  Command failed with exit code 1.
```