### PR TITLE
fix: drizzle config not loading .env.local

### DIFF
--- a/frameworks/react-cra/add-ons/drizzle/assets/drizzle.config.ts.ejs
+++ b/frameworks/react-cra/add-ons/drizzle/assets/drizzle.config.ts.ejs
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { defineConfig } from 'drizzle-kit';
 
-config();
+config({ path: '.env.local' });
 
 export default defineConfig({
   out: "./drizzle",


### PR DESCRIPTION
The generated project uses `.env.local`, but dotenv defaults to `.env`. This causes drizzle-kit commands to fail.

This PR fixes that by updating `drizzle.config.ts` to load `.env.local`.

Example error:
```
> drizzle-kit migrate

No config path provided, using default 'drizzle.config.ts'
Reading config file '/Users/duane/Projects/my-project/drizzle.config.ts'
 Error  Please provide required params for Postgres driver:
    [x] url: undefined
```