### PR TITLE
fix: import error when @tanstack/db add-on is added.

### DIFF
--- a/frameworks/react-cra/add-ons/db/assets/src/hooks/demo.useChat.ts
+++ b/frameworks/react-cra/add-ons/db/assets/src/hooks/demo.useChat.ts
@@ -3,7 +3,7 @@ import { useLiveQuery } from '@tanstack/react-db'
 
 import { messagesCollection, type Message } from '@/db-collections'
 
-import type { Collection } from '@tanstack/db'
+import type { Collection } from '@tanstack/react-db'
 
 function useStreamConnection(
   url: string,

--- a/frameworks/react-cra/add-ons/db/assets/src/routes/demo/db-chat-api.ts
+++ b/frameworks/react-cra/add-ons/db/assets/src/routes/demo/db-chat-api.ts
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 
-import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'
+import {
+  createCollection,
+  localOnlyCollectionOptions,
+} from '@tanstack/react-db'
 import { z } from 'zod'
 
 const IncomingMessageSchema = z.object({


### PR DESCRIPTION
The application was failing to start due to missing @tanstack/db module. Fixed by changing to @tanstack/react-db.

Steps to reproduce
pnpm create @tanstack/start@latest
select tanstack/db as add-on

cd into repo and pnpm dev