### PR TITLE
fix cloudflare deploy script

### DIFF
--- a/frameworks/react-cra/hosts/cloudflare/package.json
+++ b/frameworks/react-cra/hosts/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "deploy": "wrangler deploy"
+    "deploy": "npm run build && wrangler deploy"
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.13.8"


### PR DESCRIPTION
As per documentation, a build needs to run  before deploy to avoid the error about missing @tanstack/react-start/server-entry