### PR TITLE
fix: align prisma addon with v7 requirements

### DIFF
--- a/frameworks/react-cra/add-ons/prisma/assets/prisma/seed.ts.ejs
+++ b/frameworks/react-cra/add-ons/prisma/assets/prisma/seed.ts.ejs
@@ -16,8 +16,8 @@ const adapter = new PrismaMariaDb({
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
-const adapter = new PrismaBetterSQLite3({
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || 'file:./dev.db'
 });<% } %>
 

--- a/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
+++ b/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
@@ -16,8 +16,8 @@ const adapter = new PrismaMariaDb({
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
-const adapter = new PrismaBetterSQLite3({
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || 'file:./dev.db'
 });<% } %>
 

--- a/frameworks/react-cra/add-ons/prisma/package.json.ejs
+++ b/frameworks/react-cra/add-ons/prisma/package.json.ejs
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "prisma": "^6.16.3",
+    "prisma": "^7.0.0",
     "@prisma/client": "^7.0.0"<% if (addOnOption.prisma.database === 'postgres') { %>,
     "@prisma/adapter-pg": "^7.0.0"<% } %><% if (addOnOption.prisma.database === 'mysql') { %>,
     "@prisma/adapter-mariadb": "^7.0.0"<% } %><% if (addOnOption.prisma.database === 'sqlite') { %>,


### PR DESCRIPTION
- Bump prisma CLI from ^6.16.3 to ^7.0.0 to match client version
- Update PrismaBetterSQLite3 to PrismaBetterSqlite3 per v7 naming

Adapter class rename per: https://github.com/prisma/prisma/releases/tag/7.0.0