### PR TITLE
fix: Fixing tanstack query path

### DIFF
--- a/frameworks/react-cra/add-ons/tanstack-query/info.json
+++ b/frameworks/react-cra/add-ons/tanstack-query/info.json
@@ -11,7 +11,7 @@
       "icon": "Network",
       "url": "/demo/tanstack-query",
       "name": "TanStack Query",
-      "path": "src/routes/demo.tanstack-query.tsx",
+      "path": "src/routes/demo/tanstack-query.tsx",
       "jsName": "TanStackQueryDemo"
     }
   ],

--- a/frameworks/solid/add-ons/tanstack-query/info.json
+++ b/frameworks/solid/add-ons/tanstack-query/info.json
@@ -9,7 +9,7 @@
     {
       "url": "/demo/tanstack-query",
       "name": "TanStack Query",
-      "path": "src/routes/demo/tanstack-query.tsx",
+      "path": "src/routes/demo.tanstack-query.tsx",
       "jsName": "TanStackQueryDemo"
     }
   ],


### PR DESCRIPTION
I happen to use tanstack `tsrouter-app`when I installed using cli, could see following issue.

`import TanStackQueryDemo from './routes/demo.tanstack-query.tsx'`

This path is incorrect and this file `tanstack-query.tsx` is inside demo folder as shown in screenshot

<img width="1271" height="641" alt="Screenshot 2025-12-23 at 7 01 24 PM" src="https://github.com/user-attachments/assets/39591add-2cbd-4ff2-9556-265e84411d98" />
