### PR TITLE
Fixes sentry and orpc issues

### DIFF
--- a/frameworks/react-cra/add-ons/oRPC/assets/src/routes/api.$.ts
+++ b/frameworks/react-cra/add-ons/oRPC/assets/src/routes/api.$.ts
@@ -2,7 +2,7 @@ import '@/polyfill'
 
 import { OpenAPIHandler } from '@orpc/openapi/fetch'
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
-import { experimental_SmartCoercionPlugin as SmartCoercionPlugin } from '@orpc/json-schema'
+import { SmartCoercionPlugin } from '@orpc/json-schema'
 import { createFileRoute } from '@tanstack/react-router'
 import { onError } from '@orpc/server'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'

--- a/frameworks/react-cra/add-ons/oRPC/package.json
+++ b/frameworks/react-cra/add-ons/oRPC/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "@orpc/client": "^1.7.5",
-    "@orpc/json-schema": "^1.7.5",
-    "@orpc/openapi": "^1.7.5",
-    "@orpc/server": "^1.7.5",
-    "@orpc/tanstack-query": "^1.7.5",
-    "@orpc/zod": "^1.7.5",
-    "zod": "^4.0.10"
+    "@orpc/client": "^1.13.0",
+    "@orpc/json-schema": "^1.13.0",
+    "@orpc/openapi": "^1.13.0",
+    "@orpc/server": "^1.13.0",
+    "@orpc/tanstack-query": "^1.13.0",
+    "@orpc/zod": "^1.13.0",
+    "zod": "^4.2.1"
   }
 }

--- a/frameworks/react-cra/add-ons/sentry/package.json
+++ b/frameworks/react-cra/add-ons/sentry/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "vite build && cp instrument.server.mjs .output/server",
-    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
+    "dev": "dotenv -e .env.local -- sh -c \"NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000\"",
     "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
orpc issue was

```
SyntaxError: [vite] The requested module '@orpc/json-schema' does not provide an export named 'experimental_SmartCoercionPlugin'
    at analyzeImportedModDifference
 ```

VITE_SENTRY_DSN never correctly loaded at launch for me.