### PR TITLE
Fix: correct typo in SQLite adapter import

### DIFF
--- a/frameworks/react-cra/add-ons/prisma/assets/prisma/seed.ts.ejs
+++ b/frameworks/react-cra/add-ons/prisma/assets/prisma/seed.ts.ejs
@@ -16,8 +16,8 @@ const adapter = new PrismaMariaDb({
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
-const adapter = new PrismaBetterSQLite3({
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || 'file:./dev.db'
 });<% } %>
 

--- a/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
+++ b/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
@@ -16,8 +16,8 @@ const adapter = new PrismaMariaDb({
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
-const adapter = new PrismaBetterSQLite3({
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || 'file:./dev.db'
 });<% } %>
 


### PR DESCRIPTION
fixes #266

This PR fixes a typo in the better-sqlite3-adapter import within the template.
the import was incorrectly named `PrismaBetterSQLite3`, which caused errors when scaffolding a project with Prisma and SQLite.

## Changes
- Corrected `PrismaBetterSQLite3` to `PrismaBetterSqlite3` in `[frameworks/react-cra/add-ons/.../db.ts.ejs]`
- Corrected `PrismaBetterSQLite3` to `PrismaBetterSqlite3` in `[frameworks/react-cra/add-ons/.../seed.ts.ejs]`

> ref: https://www.prisma.io/docs/orm/overview/databases/sqlite#using-the-better-sqlite3-driver