### PR TITLE
chore: update Prisma add-on to v7.2.0

### DIFF
--- a/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
+++ b/frameworks/react-cra/add-ons/prisma/assets/src/db.ts.ejs
@@ -16,8 +16,8 @@ const adapter = new PrismaMariaDb({
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
-const adapter = new PrismaBetterSQLite3({
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || 'file:./dev.db'
 });<% } %>
 

--- a/frameworks/react-cra/add-ons/prisma/package.json.ejs
+++ b/frameworks/react-cra/add-ons/prisma/package.json.ejs
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "prisma": "^6.16.3",
-    "@prisma/client": "^7.0.0"<% if (addOnOption.prisma.database === 'postgres') { %>,
-    "@prisma/adapter-pg": "^7.0.0"<% } %><% if (addOnOption.prisma.database === 'mysql') { %>,
-    "@prisma/adapter-mariadb": "^7.0.0"<% } %><% if (addOnOption.prisma.database === 'sqlite') { %>,
-    "@prisma/adapter-better-sqlite3": "^7.0.0"<% } %> 
+    "prisma": "^7.2.0",
+    "@prisma/client": "^7.2.0"<% if (addOnOption.prisma.database === 'postgres') { %>,
+    "@prisma/adapter-pg": "^7.2.0"<% } %><% if (addOnOption.prisma.database === 'mysql') { %>,
+    "@prisma/adapter-mariadb": "^7.2.0"<% } %><% if (addOnOption.prisma.database === 'sqlite') { %>,
+    "@prisma/adapter-better-sqlite3": "^7.2.0"<% } %>
   },
   "devDependencies": {
     "dotenv-cli": "^10.0.0",


### PR DESCRIPTION
Update Prisma add-on packages to v7.2.0:
- `prisma` CLI: `^6.16.3` → `^7.2.0`
- `@prisma/client` and adapters: `^7.0.0` → `^7.2.0`
- Fix `PrismaBetterSqlite3` import name