### PR TITLE
fix: Fix errors with demo files by enhancing Vite config with path aliasin…

### DIFF
--- a/frameworks/react-cra/add-ons/start/assets/vite.config.ts.ejs
+++ b/frameworks/react-cra/add-ons/start/assets/vite.config.ts.ejs
@@ -2,12 +2,18 @@ import { defineConfig } from 'vite'
 import { devtools } from '@tanstack/devtools-vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react'
-import viteTsConfigPaths from 'vite-tsconfig-paths'<% if (tailwind) { %>
+import viteTsConfigPaths from 'vite-tsconfig-paths'
+import { fileURLToPath, URL } from 'url'<% if (tailwind) { %>
 import tailwindcss from "@tailwindcss/vite"
 <% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportContent(integration) %>
 <% } %>
 
 const config = defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   plugins: [devtools(), <% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportCode(integration) %>,<% } %>
     // this is the plugin that enables path aliases
     viteTsConfigPaths({


### PR DESCRIPTION
…g and imports

A lot of demo files use @ which causes issues during Vite's dependency scan