### PR TITLE
feat: add --no-toolchain option to skip toolchain selection

### DIFF
--- a/packages/cta-cli/src/cli.ts
+++ b/packages/cta-cli/src/cli.ts
@@ -338,20 +338,22 @@ Remove your node_modules directory and package lock file and re-install.`,
   }
 
   if (toolchains.size > 0) {
-    program.option<string>(
-      `--toolchain <${Array.from(toolchains).join('|')}>`,
-      `Explicitly tell the CLI to use this toolchain`,
-      (value) => {
-        if (!toolchains.has(value)) {
-          throw new InvalidArgumentError(
-            `Invalid toolchain: ${value}. The following are allowed: ${Array.from(
-              toolchains,
-            ).join(', ')}`,
-          )
-        }
-        return value
-      },
-    )
+    program
+      .option<string>(
+        `--toolchain <${Array.from(toolchains).join('|')}>`,
+        `Explicitly tell the CLI to use this toolchain`,
+        (value) => {
+          if (!toolchains.has(value)) {
+            throw new InvalidArgumentError(
+              `Invalid toolchain: ${value}. The following are allowed: ${Array.from(
+                toolchains,
+              ).join(', ')}`,
+            )
+          }
+          return value
+        },
+      )
+      .option('--no-toolchain', 'skip toolchain selection')
   }
 
   program

--- a/packages/cta-cli/src/types.ts
+++ b/packages/cta-cli/src/types.ts
@@ -7,7 +7,7 @@ export interface CliOptions {
   framework?: string
   tailwind?: boolean
   packageManager?: PackageManager
-  toolchain?: string
+  toolchain?: string | false
   deployment?: string
   projectName?: string
   git?: boolean

--- a/packages/cta-cli/src/ui-prompts.ts
+++ b/packages/cta-cli/src/ui-prompts.ts
@@ -197,8 +197,12 @@ export async function selectGit(): Promise<boolean> {
 
 export async function selectToolchain(
   framework: Framework,
-  toolchain?: string,
+  toolchain?: string | false,
 ): Promise<string | undefined> {
+  if (toolchain === false) {
+    return undefined
+  }
+
   const toolchains = new Set<AddOn>()
   for (const addOn of framework.getAddOns()) {
     if (addOn.type === 'toolchain') {


### PR DESCRIPTION
Allow users to explicitly opt out of toolchain selection via CLI by passing --no-toolchain, which skips the interactive prompt and creates the project without any toolchain (ESLint/Biome).