### PR TITLE
fix: respect --no-install flag in interactive mode

### DIFF
--- a/packages/cta-cli/src/options.ts
+++ b/packages/cta-cli/src/options.ts
@@ -191,6 +191,9 @@ export async function promptForCreateOptions(
   }
 
   options.git = cliOptions.git || (await selectGit())
+  if (cliOptions.install === false) {
+    options.install = false
+  }
 
   return options
 }


### PR DESCRIPTION
The --no-install flag was being ignored when no project name was provided (interactive mode) because promptForCreateOptions didn't pass the install option through to the final options object.