### PR TITLE
fix: add tanstackStartCookies plugin to Better Auth add-on

### DIFF
--- a/frameworks/react-cra/add-ons/better-auth/assets/src/lib/auth.ts
+++ b/frameworks/react-cra/add-ons/better-auth/assets/src/lib/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from 'better-auth'
+import { tanstackStartCookies } from 'better-auth/tanstack-start'
 
 export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  plugins: [tanstackStartCookies()],
 })

--- a/frameworks/solid/add-ons/better-auth/assets/src/lib/auth.ts
+++ b/frameworks/solid/add-ons/better-auth/assets/src/lib/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from 'better-auth'
+import { tanstackStartCookies } from 'better-auth/tanstack-start'
 
 export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  plugins: [tanstackStartCookies()],
 })


### PR DESCRIPTION
Better Auth provides an integration plugin for TanStack Start.
I missed this while trying to keep the setup minimal in a previous PR #291 🙂