### PR TITLE
fix(create): replace deprecated neon db package

### DIFF
--- a/examples/custom-cli/create-rwsdk/add-ons/neon/README.md
+++ b/examples/custom-cli/create-rwsdk/add-ons/neon/README.md
@@ -1,6 +1,6 @@
 ## Setting up Neon
 
-When running the `dev` command, the `@neondatabase/vite-plugin-postgres` will identify there is not a database setup. It will then create and seed a claimable database.
+When running the `dev` command, the `vite-plugin-neon-new` will identify there is not a database setup. It will then create and seed a claimable database.
 
 It is the same process as [Neon Launchpad](https://neon.new).
 

--- a/examples/custom-cli/create-rwsdk/add-ons/neon/assets/neon-vite-plugin.ts
+++ b/examples/custom-cli/create-rwsdk/add-ons/neon/assets/neon-vite-plugin.ts
@@ -1,6 +1,6 @@
-import { postgresPlugin } from '@neondatabase/vite-plugin-postgres'
+import { postgres } from 'vite-plugin-neon-new'
 
-export default postgresPlugin({
+export default postgres({
   seed: {
     type: 'sql-script',
     path: 'db/init.sql',

--- a/examples/custom-cli/create-rwsdk/add-ons/neon/package.json
+++ b/examples/custom-cli/create-rwsdk/add-ons/neon/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@neondatabase/serverless": "^1.0.0",
-    "@neondatabase/vite-plugin-postgres": "^0.2.0"
+    "vite-plugin-neon-new": "^0.8.0"
   }
 }

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
@@ -1,6 +1,6 @@
-import { postgresPlugin } from '@neondatabase/vite-plugin-postgres'
+import { postgres } from 'vite-plugin-neon-new'
 
-export default postgresPlugin({
+export default postgres({
   seed: {
     type: 'sql-script',
     path: 'db/init.sql',

--- a/packages/create/src/frameworks/react/add-ons/neon/package.json
+++ b/packages/create/src/frameworks/react/add-ons/neon/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
-    "@neondatabase/vite-plugin-postgres": "^0.7.0"
+    "vite-plugin-neon-new": "^0.8.0"
   }
 }


### PR DESCRIPTION
Closes https://github.com/TanStack/cli/issues/410
Closes https://github.com/TanStack/cli/issues/401

[`@neondatabase/vite-plugin-postgres`](https://www.npmjs.com/package/@neondatabase/vite-plugin-postgres) is deprecated in favor of 
[`vite-plugin-db`](https://www.npmjs.com/package/vite-plugin-db), which is deprecated and renamed to 
[`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new).

This PR updates the relevant package.jsons and updates the neon-vite-plugin to point to the new package.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Neon database plugin dependency to a newer version. All projects using the Neon add-on will automatically use the updated plugin for database initialization, configuration, and seeding operations. This change applies across both fresh project templates and example implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->