### PR TITLE
chore: add missing zod dependency

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/strapi/README.md
+++ b/packages/create/src/frameworks/react/add-ons/strapi/README.md
@@ -124,6 +124,7 @@ For production, update this to your deployed Strapi URL.
 | `react-markdown` | Markdown rendering |
 | `remark-gfm` | GitHub Flavored Markdown |
 | `use-debounce` | Debounced search input |
+| `zod` | Runtime schema validation and parsing |
 
 ### Running Both Servers
 

--- a/packages/create/src/frameworks/react/add-ons/strapi/package.json
+++ b/packages/create/src/frameworks/react/add-ons/strapi/package.json
@@ -4,6 +4,7 @@
     "lucide-react": "^0.577.0",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
-    "use-debounce": "^10.1.0"
+    "use-debounce": "^10.1.0",
+    "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
Ran into a missing dep error because Zod is used [here](https://github.com/TanStack/cli/blob/40b9c1298ce31d8af32212afd4631e8cc8780167/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.tsx#L2) but is not in the `package.json`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runtime schema validation support to the Strapi React add-on.
* **Documentation**
  * Updated the Strapi React add-on documentation to reflect the available validation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->