### PR TITLE
fix: use correct publish key in netlify.toml instead of dir

### DIFF
--- a/packages/create/src/frameworks/react/hosts/netlify/assets/netlify.toml
+++ b/packages/create/src/frameworks/react/hosts/netlify/assets/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "vite build"
-  dir = "dist/client"
+  publish = "dist/client"
 [dev]
   command = "npm run dev"
   targetPort = 3000

--- a/packages/create/src/frameworks/solid/hosts/netlify/assets/netlify.toml
+++ b/packages/create/src/frameworks/solid/hosts/netlify/assets/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "vite build"
-  dir = "dist/client"
+  publish = "dist/client"
 [dev]
   command = "npm run dev"
   targetPort = 3000


### PR DESCRIPTION
The generated netlify.toml files used dir under [build], which is not a valid Netlify configuration key. Changed it to publish as documented in the official Netlify TanStack Start guide (https://docs.netlify.com/build/frameworks/framework-setup-guides/tanstack-start/).

Closes #423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netlify build configuration for both React and Solid framework templates. Refined how the output directory is specified during the build process, ensuring Netlify correctly identifies and publishes the built site from the proper location. This applies to all new projects created with these templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->