### PR TITLE
fix(eslint): add eslint package to ESLint toolchain devDependencies

### DIFF
--- a/packages/create/src/frameworks/react/toolchains/eslint/package.json
+++ b/packages/create/src/frameworks/react/toolchains/eslint/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-config": "latest",
+    "eslint": "^9.20.0",
     "prettier": "^3.8.1"
   }
 }

--- a/packages/create/src/frameworks/solid/toolchains/eslint/package.json
+++ b/packages/create/src/frameworks/solid/toolchains/eslint/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-config": "latest",
+    "eslint": "^9.20.0",
     "prettier": "^3.8.1"
   }
 }


### PR DESCRIPTION
## Description

Closes #417

When users select the ESLint toolchain during project creation, the `eslint` package was missing from `devDependencies`, even though `@tanstack/eslint-config` declares it as a peer dependency. This caused peer dependency warnings and prevented ESLint from running properly.

## Changes

Added `"eslint": "^9.20.0"` to `devDependencies` in both React and Solid ESLint toolchain configurations:

- `packages/create/src/frameworks/react/toolchains/eslint/package.json`
- `packages/create/src/frameworks/solid/toolchains/eslint/package.json`

## Why?

`@tanstack/eslint-config` has the following peer dependency requirement:

```json
"peerDependencies": {
  "eslint": "^8.0.0 || ^9.0.0"
}
```

Peer dependencies are not automatically installed, so the CLI must explicitly include eslint in the generated project's `devDependencies` to satisfy this requirement.

## Testing

- **pnpm build** - successful
- **pnpm test** - all tests pass (75 unit + 3 e2e)
- **Manual testing**: Created a new app with ESLint toolchain and verified:
    - `eslint` package appears in `package.json` devDependencies
    - `npm run lint` executes without peer dependency warnings
    - ESLint runs correctly

## Before & After

### Before
```json
{
  "devDependencies": {
    "@tanstack/eslint-config": "latest",
    "prettier": "^3.8.1"
  }
}
```

**Missing eslint → peer dependency warning**

### After
```json
{
  "devDependencies": {
    "@tanstack/eslint-config": "latest",
    "eslint": "^9.20.0",
    "prettier": "^3.8.1"
  }
}
```

**Complete ESLint setup with all required dependencies**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ESLint (`^9.20.0`) is now an explicit development dependency in React and Solid framework toolchain configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->