### PR TITLE
fix(create): exclude demo files and better-auth integrations when demo is disabled

### DIFF
--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -29,8 +29,8 @@ function isDemoFilePath(path?: string) {
     normalized.includes('/lib/demo.') ||
     normalized.includes('/hooks/demo-') ||
     normalized.includes('/hooks/demo.') ||
-    normalized.includes('/data/demo.') ||
     normalized.includes('/data/demo-') ||
+    normalized.includes('/data/demo.') ||
     normalized.includes('/components/demo-') ||
     normalized.includes('/components/demo.')
   )
@@ -49,10 +49,15 @@ function stripExamplesFromOptions(options: Options): Options {
           !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
+      
+      const filteredIntegrations = (addOn.integrations || []).filter(
+        (integration) => !isDemoFilePath(integration.path)
+      )
 
       return {
         ...addOn,
         routes: filteredRoutes,
+        integrations: filteredIntegrations,
         getFiles: async () => {
           const files = await addOn.getFiles()
           return files.filter((file) => !isDemoFilePath(file))

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -17,14 +17,22 @@ import { runSpecialSteps } from './special-steps/index.js'
 
 import type { Environment, FileBundleHandler, Options } from './types.js'
 
-function isDemoRoutePath(path?: string) {
+function isDemoFilePath(path?: string) {
   if (!path) return false
   const normalized = path.replace(/\\/g, '/')
   return (
     normalized.includes('/routes/demo/') ||
     normalized.includes('/routes/demo.') ||
     normalized.includes('/routes/example/') ||
-    normalized.includes('/routes/example.')
+    normalized.includes('/routes/example.') ||
+    normalized.includes('/lib/demo-') ||
+    normalized.includes('/lib/demo.') ||
+    normalized.includes('/hooks/demo-') ||
+    normalized.includes('/hooks/demo.') ||
+    normalized.includes('/data/demo.') ||
+    normalized.includes('/data/demo-') ||
+    normalized.includes('/components/demo-') ||
+    normalized.includes('/components/demo.')
   )
 }
 
@@ -38,7 +46,7 @@ function stripExamplesFromOptions(options: Options): Options {
     .map((addOn) => {
       const filteredRoutes = (addOn.routes || []).filter(
         (route) =>
-          !isDemoRoutePath(route.path) &&
+          !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
 
@@ -47,11 +55,11 @@ function stripExamplesFromOptions(options: Options): Options {
         routes: filteredRoutes,
         getFiles: async () => {
           const files = await addOn.getFiles()
-          return files.filter((file) => !isDemoRoutePath(file))
+          return files.filter((file) => !isDemoFilePath(file))
         },
         getDeletedFiles: async () => {
           const deletedFiles = await addOn.getDeletedFiles()
-          return deletedFiles.filter((file) => !isDemoRoutePath(file))
+          return deletedFiles.filter((file) => !isDemoFilePath(file))
         },
       }
     })

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
@@ -1,5 +1,7 @@
 import { authClient } from "#/lib/auth-client";
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
 import { Link } from "@tanstack/react-router";
+<%_ } _%>
 
 export default function BetterAuthHeader() {
   const { data: session, isPending } = authClient.useSession();
@@ -34,6 +36,7 @@ export default function BetterAuthHeader() {
     );
   }
 
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
   return (
     <Link
       to="/demo/better-auth"
@@ -42,4 +45,7 @@ export default function BetterAuthHeader() {
       Sign in
     </Link>
   );
+<%_ } else { _%>
+  return null;
+<%_ } _%>
 }

--- a/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
+++ b/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
@@ -1,5 +1,7 @@
 import { Show } from "solid-js";
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
 import { Link } from "@tanstack/solid-router";
+<%_ } _%>
 import { authClient } from "../../lib/auth-client";
 
 export default function BetterAuthHeader() {
@@ -14,6 +16,7 @@ export default function BetterAuthHeader() {
     >
       <Show
         when={session().data?.user}
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
         fallback={
           <Link
             to="/demo/better-auth"
@@ -22,6 +25,7 @@ export default function BetterAuthHeader() {
             Sign in
           </Link>
         }
+<%_ } _%>
       >
         {(user) => (
           <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

  - Previously, only demo route files were filtered when users opted out of demo files. Files in `components/`, `lib/`, `hooks/`, and
   `data/` were still being created.
  - Renamed `isDemoRoutePath` → `isDemoFilePath` and extended pattern matching to cover all non-route demo paths.
  - The Better Auth header/user components referenced `/demo/better-auth`, a route that doesn't exist without demo files. Converted
  them to EJS templates that conditionally render `null` when demo is disabled.
  - Extended `isDemoFilePath` filtering to also cover add-on integration files.

  ## Test plan

  - [ ] Create app with Better Auth add-on, opt out of demo — header/user components should render without broken route links
  - [ ] Create app without demo — verify no demo files appear in `components/`, `lib/`, `hooks/`, or `data/`
  - [ ] Create app with demo — verify all demo files still present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced demo content detection to recognize demo files across additional directories.

* **Bug Fixes**
  * Fixed conditional rendering of demo integrations to properly display only when demo routes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->