### PR TITLE
fix(create): strip all demo/example files when users opt out

### DIFF
--- a/.changeset/fix-demo-file-leaks.md
+++ b/.changeset/fix-demo-file-leaks.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/create': patch
+---
+
+Fix demo/example files leaking into projects when users opt out of demo pages.
+
+- Strip add-on demo support files in `src/lib/`, `src/hooks/`, `src/data/`, `src/components/`, `src/store/`, and any `demo.*` / `demo-*` / `example.*` / `example-*` files.
+- Strip example image assets under `public/`.
+- Generate a minimal base starter (no Header, Footer, ThemeToggle, about page, or styled index page) when declining demo/example pages.
+- Render Better Auth header-user component as `null` when its demo route is excluded, instead of linking to a non-existent route.
+
+Closes #422, #409.

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -20,19 +20,20 @@ import type { Environment, FileBundleHandler, Options } from './types.js'
 function isDemoFilePath(path?: string) {
   if (!path) return false
   const normalized = path.replace(/\\/g, '/')
-  return (
+
+  if (
     normalized.includes('/routes/demo/') ||
-    normalized.includes('/routes/demo.') ||
-    normalized.includes('/routes/example/') ||
-    normalized.includes('/routes/example.') ||
-    normalized.includes('/lib/demo-') ||
-    normalized.includes('/lib/demo.') ||
-    normalized.includes('/hooks/demo-') ||
-    normalized.includes('/hooks/demo.') ||
-    normalized.includes('/data/demo-') ||
-    normalized.includes('/data/demo.') ||
-    normalized.includes('/components/demo-') ||
-    normalized.includes('/components/demo.')
+    normalized.includes('/routes/example/')
+  ) {
+    return true
+  }
+
+  const filename = normalized.split('/').pop() || ''
+  return (
+    filename.startsWith('demo.') ||
+    filename.startsWith('demo-') ||
+    filename.startsWith('example.') ||
+    filename.startsWith('example-')
   )
 }
 

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -29,8 +29,8 @@ function isDemoFilePath(path?: string) {
     normalized.includes('/lib/demo.') ||
     normalized.includes('/hooks/demo-') ||
     normalized.includes('/hooks/demo.') ||
-    normalized.includes('/data/demo.') ||
     normalized.includes('/data/demo-') ||
+    normalized.includes('/data/demo.') ||
     normalized.includes('/components/demo-') ||
     normalized.includes('/components/demo.')
   )
@@ -49,10 +49,15 @@ function stripExamplesFromOptions(options: Options): Options {
           !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
+      
+      const filteredIntegrations = (addOn.integrations || []).filter(
+        (integration) => !isDemoFilePath(integration.path)
+      )
 
       return {
         ...addOn,
         routes: filteredRoutes,
+        integrations: filteredIntegrations,
         getFiles: async () => {
           const files = await addOn.getFiles()
           return files.filter((file) => !isDemoFilePath(file))

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -17,14 +17,22 @@ import { runSpecialSteps } from './special-steps/index.js'
 
 import type { Environment, FileBundleHandler, Options } from './types.js'
 
-function isDemoRoutePath(path?: string) {
+function isDemoFilePath(path?: string) {
   if (!path) return false
   const normalized = path.replace(/\\/g, '/')
   return (
     normalized.includes('/routes/demo/') ||
     normalized.includes('/routes/demo.') ||
     normalized.includes('/routes/example/') ||
-    normalized.includes('/routes/example.')
+    normalized.includes('/routes/example.') ||
+    normalized.includes('/lib/demo-') ||
+    normalized.includes('/lib/demo.') ||
+    normalized.includes('/hooks/demo-') ||
+    normalized.includes('/hooks/demo.') ||
+    normalized.includes('/data/demo.') ||
+    normalized.includes('/data/demo-') ||
+    normalized.includes('/components/demo-') ||
+    normalized.includes('/components/demo.')
   )
 }
 
@@ -38,7 +46,7 @@ function stripExamplesFromOptions(options: Options): Options {
     .map((addOn) => {
       const filteredRoutes = (addOn.routes || []).filter(
         (route) =>
-          !isDemoRoutePath(route.path) &&
+          !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
 
@@ -47,11 +55,11 @@ function stripExamplesFromOptions(options: Options): Options {
         routes: filteredRoutes,
         getFiles: async () => {
           const files = await addOn.getFiles()
-          return files.filter((file) => !isDemoRoutePath(file))
+          return files.filter((file) => !isDemoFilePath(file))
         },
         getDeletedFiles: async () => {
           const deletedFiles = await addOn.getDeletedFiles()
-          return deletedFiles.filter((file) => !isDemoRoutePath(file))
+          return deletedFiles.filter((file) => !isDemoFilePath(file))
         },
       }
     })

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
@@ -1,5 +1,7 @@
 import { authClient } from "#/lib/auth-client";
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
 import { Link } from "@tanstack/react-router";
+<%_ } _%>
 
 export default function BetterAuthHeader() {
   const { data: session, isPending } = authClient.useSession();
@@ -34,6 +36,7 @@ export default function BetterAuthHeader() {
     );
   }
 
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
   return (
     <Link
       to="/demo/better-auth"
@@ -42,4 +45,7 @@ export default function BetterAuthHeader() {
       Sign in
     </Link>
   );
+<%_ } else { _%>
+  return null;
+<%_ } _%>
 }

--- a/packages/create/src/frameworks/react/project/base/src/components/Footer.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/components/Footer.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 export default function Footer() {
   const year = new Date().getFullYear()
 

--- a/packages/create/src/frameworks/react/project/base/src/components/Header.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/components/Header.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 import { Link } from '@tanstack/react-router'
 <% for (const integration of integrations.filter((i) => i.type === 'header-user')) { %>import <%= integration.jsName %> from '<%= relativePath(integration.path) %>'
 <% } %>import ThemeToggle from './ThemeToggle'

--- a/packages/create/src/frameworks/react/project/base/src/components/ThemeToggle.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/components/ThemeToggle.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 import { useEffect, useState } from 'react'
 
 type ThemeMode = 'light' | 'dark' | 'auto'

--- a/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
@@ -27,6 +27,99 @@ function RootComponent() {
     </>
   )
 }
+<% } else if (!includeExamples) { %>
+<% let hasContext = addOnEnabled["apollo-client"] || addOnEnabled["tanstack-query"]; %>
+import {
+  HeadContent, Scripts, <% if (hasContext) { %>createRootRouteWithContext<% } else { %>createRootRoute<% } %> } from '@tanstack/react-router'
+import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
+import { TanStackDevtools } from '@tanstack/react-devtools'
+<% for(const integration of integrations.filter(i => i.type === 'layout' || i.type === 'provider' || i.type === 'devtools')) { %>
+import <%= integration.jsName %> from '<%= relativePath(integration.path, true) %>'
+<% } %><% if (addOnEnabled.paraglide) { %>
+import { getLocale } from '#/paraglide/runtime'
+<% } %>
+import appCss from '../styles.css?url'
+<% if (addOnEnabled["apollo-client"]) { %>
+import type { ApolloClientIntegration } from "@apollo/client-integration-tanstack-start";
+<% } %>
+<% if (addOnEnabled["tanstack-query"]) { %>
+import type { QueryClient } from '@tanstack/react-query'
+<% if (addOnEnabled.tRPC) { %>
+import type { TRPCRouter } from '#/integrations/trpc/router'
+import type { TRPCOptionsProxy } from '@trpc/tanstack-react-query'
+<% } %>
+<% } %>
+<% if (hasContext) { %>
+interface MyRouterContext <% if (addOnEnabled["apollo-client"]) {%> extends ApolloClientIntegration.RouterContext <%} %>{
+<% if (addOnEnabled["tanstack-query"]) { %>
+  queryClient: QueryClient
+  <% if (addOnEnabled.tRPC) { %>
+  trpc: TRPCOptionsProxy<TRPCRouter>
+  <% } %>
+<% } %>
+}<% } %>
+
+export const Route = <% if (hasContext) { %>createRootRouteWithContext<MyRouterContext>()<% } else { %>createRootRoute<% } %>({
+<% if (addOnEnabled.paraglide) { %>
+  beforeLoad: async () => {
+    // Other redirect strategies are possible; see
+    // https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide#offline-redirect
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('lang', getLocale())
+    }
+  },
+<% } %>
+  head: () => ({
+    meta: [
+      {
+        charSet: 'utf-8',
+      },
+      {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1',
+      },
+      {
+        title: 'TanStack Start Starter',
+      },
+    ],
+    links: [
+      {
+        rel: 'stylesheet',
+        href: appCss,
+      },
+    ],
+  }),
+  shellComponent: RootDocument
+})
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+      <% if (addOnEnabled.paraglide) { %><html lang={getLocale()}><% } else { %><html lang="en"><% } %>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <% for(const integration of integrations.filter(i => i.type === 'provider')) { %><<%= integration.jsName %>>
+        <% } %>{children}
+          <TanStackDevtools
+            config={{
+              position: 'bottom-right',
+            }}
+            plugins={[
+              {
+                name: 'Tanstack Router',
+                render: <TanStackRouterDevtoolsPanel />,
+              },
+              <% for(const integration of integrations.filter(i => i.type === 'devtools')) { %><%= integration.jsName %>,<% } %>
+            ]}
+          />
+          <% for(const integration of integrations.filter(i => i.type === 'layout')) { %><<%= integration.jsName %> />
+          <% } %><% for(const integration of integrations.filter(i => i.type === 'provider').reverse()) { %></<%= integration.jsName %>>
+        <% } %><Scripts />
+      </body>
+    </html>
+  )
+}
 <% } else { %>
 <% let hasContext = addOnEnabled["apollo-client"] || addOnEnabled["tanstack-query"]; %>
 import {

--- a/packages/create/src/frameworks/react/project/base/src/routes/about.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/routes/about.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/about')({

--- a/packages/create/src/frameworks/react/project/base/src/routes/index.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/routes/index.tsx.ejs
@@ -1,3 +1,19 @@
+<% if (!includeExamples) { %>
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/")({ component: Home });
+
+function Home() {
+  return (
+    <div className="p-8">
+      <h1 className="text-4xl font-bold">Welcome to TanStack Start</h1>
+      <p className="mt-4 text-lg">
+        Edit <code>src/routes/index.tsx</code> to get started.
+      </p>
+    </div>
+  );
+}
+<% } else { %>
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({ component: App });
@@ -70,3 +86,4 @@ function App() {
     </main>
   );
 }
+<% } %>

--- a/packages/create/src/frameworks/react/project/base/src/styles.css.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/styles.css.ejs
@@ -1,3 +1,20 @@
+<% if (!includeExamples) { %>
+@import "tailwindcss";
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+}
+<% } else { %>
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
@@ -257,3 +274,4 @@ a {
     transform: translateY(0);
   }
 }
+<% } %>

--- a/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
+++ b/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx.ejs
@@ -1,5 +1,7 @@
 import { Show } from "solid-js";
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
 import { Link } from "@tanstack/solid-router";
+<%_ } _%>
 import { authClient } from "../../lib/auth-client";
 
 export default function BetterAuthHeader() {
@@ -14,6 +16,7 @@ export default function BetterAuthHeader() {
     >
       <Show
         when={session().data?.user}
+<%_ if (routes.some(r => r.url === '/demo/better-auth')) { _%>
         fallback={
           <Link
             to="/demo/better-auth"
@@ -22,6 +25,7 @@ export default function BetterAuthHeader() {
             Sign in
           </Link>
         }
+<%_ } _%>
       >
         {(user) => (
           <div class="flex items-center gap-2">

--- a/packages/create/src/frameworks/solid/project/base/src/components/Header.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/components/Header.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 import { Link } from '@tanstack/solid-router'
 <% for(const integration of integrations.filter(i => i.type === 'header-user')) { %>
 import <%= integration.jsName %> from '<%= relativePath(integration.path) %>'

--- a/packages/create/src/frameworks/solid/project/base/src/routes/__root.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/routes/__root.tsx.ejs
@@ -46,9 +46,9 @@ function RootComponent() {
       <html>
         <head>
           <HydrationScript />
+          <HeadContent />
         </head>
         <body>
-          <HeadContent />
           <Suspense>
             <Outlet />
             <TanStackRouterDevtools />
@@ -92,9 +92,9 @@ function RootComponent() {
       <html>
         <head>
           <HydrationScript />
+          <HeadContent />
         </head>
         <body>
-          <HeadContent />
           <Suspense>
             <Header />
             <Outlet />

--- a/packages/create/src/frameworks/solid/project/base/src/routes/__root.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/routes/__root.tsx.ejs
@@ -16,6 +16,51 @@ function RootComponent() {
     </>
   )
 }
+<% } else if (!includeExamples) { %>
+import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from '@tanstack/solid-router'
+import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'
+
+<% if (addOnEnabled['solid-ui']) { %>
+import "@fontsource/inter/400.css"
+<% } %>
+
+import { HydrationScript } from 'solid-js/web'
+import { Suspense } from 'solid-js'
+
+<% for(const addOn of addOns) {
+  for(const init of addOn.main?.initialize || []) { %>
+  <%- init %>
+<% } } %>
+
+import styleCss from "../styles.css?url";
+
+export const Route = createRootRouteWithContext()({
+  head: () => ({
+    links: [{ rel: "stylesheet", href: styleCss }],
+  }),
+  shellComponent: RootComponent,
+})
+
+function RootComponent() {
+    return (
+      <html>
+        <head>
+          <HydrationScript />
+        </head>
+        <body>
+          <HeadContent />
+          <Suspense>
+            <Outlet />
+            <TanStackRouterDevtools />
+            <% for(const integration of integrations.filter(i => i.type === 'layout')) { %>
+              <<%= integration.jsName %> />
+            <% } %>
+            </Suspense>
+          <Scripts />
+        </body>
+      </html>
+    );
+}
 <% } else { %>
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from '@tanstack/solid-router'
 import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'

--- a/packages/create/src/frameworks/solid/project/base/src/routes/about.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/routes/about.tsx.ejs
@@ -1,3 +1,4 @@
+<% if (!includeExamples) { ignoreFile(); return; } %>
 import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/about')({

--- a/packages/create/src/frameworks/solid/project/base/src/routes/index.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/routes/index.tsx.ejs
@@ -1,3 +1,19 @@
+<% if (!includeExamples) { %>
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/')({ component: Home })
+
+function Home() {
+  return (
+    <div class="p-8">
+      <h1 class="text-4xl font-bold">Welcome to TanStack Start</h1>
+      <p class="mt-4 text-lg">
+        Edit <code>src/routes/index.tsx</code> to get started.
+      </p>
+    </div>
+  )
+}
+<% } else { %>
 import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/')({ component: App })
@@ -66,3 +82,4 @@ function App() {
     </main>
   )
 }
+<% } %>

--- a/packages/create/src/frameworks/solid/project/base/src/styles.css.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/styles.css.ejs
@@ -1,3 +1,20 @@
+<% if (!includeExamples) { %>
+@import 'tailwindcss';
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+}
+<% } else { %>
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap');
 @import 'tailwindcss';
 
@@ -193,3 +210,4 @@ code {
     transform: translateY(0);
   }
 }
+<% } %>

--- a/packages/create/src/template-file.ts
+++ b/packages/create/src/template-file.ts
@@ -137,6 +137,7 @@ export function createTemplateFile(environment: Environment, options: Options) {
       fileRouter: options.mode === 'file-router',
       codeRouter: options.mode === 'code-router',
       routerOnly: options.routerOnly === true,
+      includeExamples: options.includeExamples !== false,
       addOnEnabled,
       addOnOption: options.addOnOptions,
       addOns: options.chosenAddOns,

--- a/packages/create/tests/create-app.test.ts
+++ b/packages/create/tests/create-app.test.ts
@@ -117,4 +117,81 @@ describe('createApp', () => {
     expect(output.files['/src/test2.txt']).toEqual('base64::aGVsbG8=')
     expect(output.commands.some(({ command }) => command === 'echo')).toBe(true)
   })
+
+  it('should strip demo files from add-ons when includeExamples is false', async () => {
+    const { environment, output } = createMemoryEnvironment()
+
+    const demoFiles = [
+      'src/routes/demo/form.simple.tsx',
+      'src/routes/demo.form.tsx',
+      'src/routes/example.chat.tsx',
+      'src/components/demo-AIAssistant.tsx',
+      'src/components/demo.FormComponents.tsx',
+      'src/hooks/demo-useAudioRecorder.ts',
+      'src/hooks/demo.form.ts',
+      'src/lib/demo-store.ts',
+      'src/lib/demo.ai-hook.ts',
+      'src/data/demo-guitars.ts',
+      'src/store/demo.hooks.ts',
+      'src/store/demo.store.ts',
+      'src/demo.index.css',
+      'public/demo-neon.svg',
+      'public/example-guitar-flowers.jpg',
+    ]
+    const keepFiles = [
+      'src/routes/index.tsx',
+      'src/components/Header.tsx',
+      'src/lib/utils.ts',
+    ]
+    const allFiles = [...demoFiles, ...keepFiles]
+
+    await createApp(environment, {
+      ...simpleOptions,
+      includeExamples: false,
+      chosenAddOns: [
+        {
+          id: 'test-addon',
+          type: 'add-on',
+          phase: 'add-on',
+          packageAdditions: { dependencies: {}, devDependencies: {} },
+          routes: [],
+          integrations: [],
+          getFiles: () => allFiles,
+          getFileContents: () => 'content',
+          getDeletedFiles: () => [],
+        } as unknown as AddOn,
+      ],
+    } as Options)
+
+    for (const file of demoFiles) {
+      expect(output.files[`/${file}`]).toBeUndefined()
+    }
+    for (const file of keepFiles) {
+      expect(output.files[`/${file}`]).toBeDefined()
+    }
+  })
+
+  it('should keep demo files from add-ons when includeExamples is true', async () => {
+    const { environment, output } = createMemoryEnvironment()
+
+    await createApp(environment, {
+      ...simpleOptions,
+      includeExamples: true,
+      chosenAddOns: [
+        {
+          id: 'test-addon',
+          type: 'add-on',
+          phase: 'add-on',
+          packageAdditions: { dependencies: {}, devDependencies: {} },
+          routes: [],
+          integrations: [],
+          getFiles: () => ['src/components/demo-AIAssistant.tsx'],
+          getFileContents: () => 'content',
+          getDeletedFiles: () => [],
+        } as unknown as AddOn,
+      ],
+    } as Options)
+
+    expect(output.files['/src/components/demo-AIAssistant.tsx']).toBeDefined()
+  })
 })

--- a/packages/create/tests/template-context.test.ts
+++ b/packages/create/tests/template-context.test.ts
@@ -312,3 +312,66 @@ export const db = testAddon(/* connection */)`
     expect(output.files['/test/src/db/__postgres__index.ts']).toBeUndefined()
   })
 })
+
+describe('Template Context - includeExamples', () => {
+  it('should default includeExamples to true when undefined', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    const templateFile = createTemplateFile(environment, simpleOptions)
+    environment.startRun()
+    await templateFile(
+      'test.txt.ejs',
+      '<%= includeExamples ? "with-examples" : "no-examples" %>',
+    )
+    environment.finishRun()
+
+    expect(output.files['/test/test.txt']).toEqual('with-examples')
+  })
+
+  it('should set includeExamples to false when options.includeExamples is false', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    const templateFile = createTemplateFile(environment, {
+      ...simpleOptions,
+      includeExamples: false,
+    })
+    environment.startRun()
+    await templateFile(
+      'test.txt.ejs',
+      '<%= includeExamples ? "with-examples" : "no-examples" %>',
+    )
+    environment.finishRun()
+
+    expect(output.files['/test/test.txt']).toEqual('no-examples')
+  })
+
+  it('should ignore files when includeExamples is false', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    const templateFile = createTemplateFile(environment, {
+      ...simpleOptions,
+      includeExamples: false,
+    })
+    environment.startRun()
+    await templateFile(
+      'about.ts.ejs',
+      '<% if (!includeExamples) { ignoreFile(); return; } %>\nexport const about = true',
+    )
+    environment.finishRun()
+
+    expect(output.files['/test/about.ts']).toBeUndefined()
+  })
+
+  it('should include files when includeExamples is true', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    const templateFile = createTemplateFile(environment, {
+      ...simpleOptions,
+      includeExamples: true,
+    })
+    environment.startRun()
+    await templateFile(
+      'about.ts.ejs',
+      '<% if (!includeExamples) { ignoreFile(); return; } %>\nexport const about = true',
+    )
+    environment.finishRun()
+
+    expect(output.files['/test/about.ts']).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #422 and #409 — when users select "No" for "Would you like to include demo/example pages?", a lot of demo boilerplate was still getting scaffolded.

This PR combines the work from @WaryaWayne ([#431](https://github.com/TanStack/cli/pull/431)) and @wyMinLwin ([#429](https://github.com/TanStack/cli/pull/429)) into a single unified fix, plus additional coverage for edge cases they missed. Both original commits are preserved with author credit.

## What was leaking through

The previous filter only matched files under `/routes/demo/` or `/routes/demo.*`. Demo support files in `/lib/`, `/hooks/`, `/data/`, `/components/`, `/store/`, at the `src/` root (`demo.index.css`), and example assets in `/public/` (`example-guitar-*.jpg`, `demo-neon.svg`) were all being copied into new projects with no routes referencing them. On top of that, the base scaffolding always shipped a `Header`, `Footer`, `ThemeToggle`, styled landing page, and About route — even when the user wanted a minimal starter.

## Fixes

From @WaryaWayne's #431:
- Rename `isDemoRoutePath` → `isDemoFilePath` and expand it to cover support files in `lib`, `hooks`, `data`, `components`
- Extend filtering to add-on `integrations` (not just routes and files)
- Convert Better Auth header-user component to an EJS template that renders `null` when its demo route is excluded, instead of linking to a non-existent route

From @wyMinLwin's #429:
- Pipe `includeExamples` into the template context
- Conditionally render the base `Header`, `Footer`, `ThemeToggle`, `About` route, styled `index` route, and styles when demo pages are disabled
- Add template-context tests for the new flag

Additional cleanup I layered on top:
- Replace the directory-specific list with a filename-prefix match so any file whose basename starts with `demo.`, `demo-`, `example.`, or `example-` gets stripped, regardless of which directory it lives in. This catches the `/store/demo.*`, `/public/example-*`, and `src/demo.index.css` cases the original approach missed.
- Add a regression test that exercises the filter against demo files across `lib`, `hooks`, `data`, `components`, `store`, `public`, and `routes`.

## Test plan

- [x] Unit tests: `pnpm --filter @tanstack/create test` (194 passed)
- [x] CLI unit tests: `pnpm --filter @tanstack/cli test` (84 passed)
- [x] E2E smoke tests: `pnpm --filter @tanstack/cli test:e2e` (3 passed — create, solid, addons)
- [x] Manual: `tanstack create ... --no-examples --add-ons=ai,form,table,store,db,tanstack-query` produces a project with no `demo*`/`example*` files in `src/` or `public/`, and no Header/Footer/ThemeToggle in the base scaffolding
- [x] Manual: `tanstack create ... --examples --add-ons=tanstack-query` keeps Header/Footer/ThemeToggle and demo routes

Co-authored-by: Abdullahi Mohamed <126521894+WaryaWayne@users.noreply.github.com>
Co-authored-by: wyMinLwin <waiyanminlwin421@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added minimal starter template option that excludes demo and example artifacts, providing a clean foundation for custom projects.

* **Bug Fixes**
  * Fixed demo and example files from leaking into projects when users opt out of demo pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->