### PR TITLE
fix(cli): default to interactive mode and add missing prompts

### DIFF
--- a/.changeset/fix-interactive-prompts.md
+++ b/.changeset/fix-interactive-prompts.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/cli': patch
+---
+
+Fix interactive mode not prompting for all options.
+
+- Default to interactive mode. Previously, `tanstack create my-app` silently applied defaults for framework, deployment, and install. Opt out with `--yes` / `--non-interactive`.
+- Add framework selection prompt when the CLI supports multiple frameworks and no `--framework` flag is passed.
+- Add "install dependencies now?" prompt when `--no-install` is not passed.
+- Show deployment adapter prompt by default (previously required `showDeploymentOptions: true`).
+- Honor `forcedDeployment` as the default selection in the deployment prompt, so deprecated aliases keep a sensible default.
+- Preserve explicit `--add-ons` arrays instead of overwriting them with the interactive sentinel.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -238,7 +238,7 @@ export function cli({
   forcedDeployment,
   defaultFramework,
   frameworkDefinitionInitializers,
-  showDeploymentOptions = false,
+  showDeploymentOptions = true,
   legacyAutoCreate = false,
   defaultRouterOnly = false,
 }: {
@@ -649,9 +649,11 @@ export function cli({
             cliOptions.routerOnly = true
           }
 
-          cliOptions.framework = getFrameworkByName(
-            options.framework || defaultFramework || 'React',
-          )!.id
+          if (options.framework) {
+            cliOptions.framework = getFrameworkByName(options.framework)!.id
+          } else if (defaultFramework) {
+            cliOptions.framework = getFrameworkByName(defaultFramework)!.id
+          }
 
           const nonInteractive = !!cliOptions.nonInteractive || !!cliOptions.yes
           if (cliOptions.interactive && nonInteractive) {
@@ -660,16 +662,23 @@ export function cli({
             )
           }
 
-          const addOnsFlagPassed = process.argv.includes('--add-ons')
+          const hasInteractiveTerminal =
+            !!process.stdin.isTTY && !!process.stdout.isTTY && !process.env.CI
           const wantsInteractiveMode =
             !nonInteractive &&
-            (cliOptions.interactive ||
-              (cliOptions.addOns === true && addOnsFlagPassed))
+            (cliOptions.interactive || hasInteractiveTerminal)
 
           let finalOptions: Options | undefined
           if (wantsInteractiveMode) {
-            cliOptions.addOns = true
+            if (cliOptions.addOns === undefined) {
+              cliOptions.addOns = true
+            }
           } else {
+            if (!cliOptions.framework) {
+              cliOptions.framework = getFrameworkByName(
+                defaultFramework || 'React',
+              )!.id
+            }
             finalOptions = await normalizeOptions(
               cliOptions,
               forcedAddOns,
@@ -677,18 +686,16 @@ export function cli({
             )
           }
 
-          if (nonInteractive) {
-            if (cliOptions.addOns === true) {
-              throw new Error(
-                'When using --non-interactive/--yes, pass explicit add-ons via --add-ons <ids>.',
-              )
-            }
+          if (!wantsInteractiveMode && cliOptions.addOns === true) {
+            throw new Error(
+              'When running non-interactively, pass explicit add-ons via --add-ons <ids>.',
+            )
           }
 
           if (finalOptions) {
             intro(`Creating a new ${appName} app in ${projectName}...`)
           } else {
-            if (nonInteractive) {
+            if (!wantsInteractiveMode) {
               throw new Error(
                 'Project name is required in non-interactive mode. Pass [project-name] or --target-dir.',
               )
@@ -696,7 +703,11 @@ export function cli({
             intro(`Let's configure your ${appName} application`)
             finalOptions = await promptForCreateOptions(cliOptions, {
               forcedAddOns,
+              forcedDeployment,
               showDeploymentOptions,
+              defaultFrameworkId: defaultFramework
+                ? getFrameworkByName(defaultFramework)?.id
+                : undefined,
             })
           }
 
@@ -756,7 +767,6 @@ export function cli({
           }
           return value
         },
-        defaultFramework || 'React',
       )
     }
 

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -3,6 +3,7 @@ import { intro } from '@clack/prompts'
 import {
   finalizeAddOns,
   getFrameworkById,
+  getFrameworks,
   getPackageManager,
   loadStarter,
   populateAddOnOptionsDefaults,
@@ -16,7 +17,9 @@ import {
   selectAddOns,
   selectDeployment,
   selectExamples,
+  selectFramework,
   selectGit,
+  selectInstall,
   selectPackageManager,
   selectTemplate,
   selectToolchain,
@@ -39,15 +42,31 @@ export async function promptForCreateOptions(
   cliOptions: CliOptions,
   {
     forcedAddOns = [],
-    showDeploymentOptions = false,
+    forcedDeployment,
+    showDeploymentOptions = true,
+    defaultFrameworkId,
   }: {
     forcedAddOns?: Array<string>
+    forcedDeployment?: string
     showDeploymentOptions?: boolean
+    defaultFrameworkId?: string
   },
 ): Promise<Required<Options> | undefined> {
   const options = {} as Required<Options>
 
-  options.framework = getFrameworkById(cliOptions.framework || 'react')!
+  if (cliOptions.framework) {
+    options.framework = getFrameworkById(cliOptions.framework)!
+  } else {
+    const availableFrameworks = getFrameworks()
+    if (defaultFrameworkId || availableFrameworks.length <= 1) {
+      options.framework = getFrameworkById(defaultFrameworkId || 'react')!
+    } else {
+      options.framework = await selectFramework(
+        availableFrameworks,
+        defaultFrameworkId,
+      )
+    }
+  }
 
   // Validate project name
   if (cliOptions.projectName) {
@@ -130,11 +149,20 @@ export async function promptForCreateOptions(
   )
 
   // Deployment selection
-  const deployment = showDeploymentOptions
-    ? routerOnly
-      ? undefined
-      : await selectDeployment(options.framework, cliOptions.deployment)
-    : undefined
+  let deployment: string | undefined
+  if (routerOnly) {
+    deployment = undefined
+  } else if (cliOptions.deployment) {
+    deployment = cliOptions.deployment
+  } else if (showDeploymentOptions) {
+    deployment = await selectDeployment(
+      options.framework,
+      cliOptions.deployment,
+      forcedDeployment,
+    )
+  } else {
+    deployment = forcedDeployment
+  }
 
   // Add-ons selection
   const addOns: Set<string> = new Set()
@@ -226,9 +254,7 @@ export async function promptForCreateOptions(
     envVarValues
 
   options.git = cliOptions.git ?? (await selectGit())
-  if (cliOptions.install === false) {
-    options.install = false
-  }
+  options.install = cliOptions.install ?? (await selectInstall())
 
   if (starter) {
     options.starter = starter

--- a/packages/cli/src/ui-prompts.ts
+++ b/packages/cli/src/ui-prompts.ts
@@ -20,6 +20,47 @@ import type { AddOn, PackageManager } from '@tanstack/create'
 
 import type { Framework } from '@tanstack/create/dist/types/types.js'
 
+export async function selectFramework(
+  frameworks: Array<Framework>,
+  defaultFrameworkId?: string,
+): Promise<Framework> {
+  const initialValue =
+    (defaultFrameworkId &&
+      frameworks.find(
+        (f) => f.id.toLowerCase() === defaultFrameworkId.toLowerCase(),
+      )?.id) ||
+    frameworks[0]!.id
+
+  const selected = await select({
+    message: 'Select framework:',
+    options: frameworks.map((f) => ({ value: f.id, label: f.name })),
+    initialValue,
+  })
+
+  if (isCancel(selected)) {
+    cancel('Operation cancelled.')
+    process.exit(0)
+  }
+
+  const framework = frameworks.find((f) => f.id === selected)
+  if (!framework) {
+    throw new Error(`Unknown framework: ${selected}`)
+  }
+  return framework
+}
+
+export async function selectInstall(): Promise<boolean> {
+  const install = await confirm({
+    message: 'Would you like to install dependencies now?',
+    initialValue: true,
+  })
+  if (isCancel(install)) {
+    cancel('Operation cancelled.')
+    process.exit(0)
+  }
+  return install
+}
+
 export async function getProjectName(): Promise<string> {
   const value = await text({
     message: 'What would you like to name your project?',
@@ -350,6 +391,7 @@ export async function promptForEnvVars(
 export async function selectDeployment(
   framework: Framework,
   deployment?: string,
+  forcedDeployment?: string,
 ): Promise<string | undefined> {
   const deployments = new Set<AddOn>()
   let initialValue: string | undefined = undefined
@@ -361,21 +403,28 @@ export async function selectDeployment(
       if (deployment && addOn.id === deployment) {
         return deployment
       }
-      if (addOn.default) {
+      if (forcedDeployment && addOn.id === forcedDeployment) {
+        initialValue = addOn.id
+      } else if (!initialValue && addOn.default) {
         initialValue = addOn.id
       }
     }
   }
 
+  if (deployments.size === 0) {
+    return undefined
+  }
+
   const dp = await select({
-    message: 'Select deployment adapter',
+    message: 'Select deployment adapter:',
     options: [
+      { value: undefined, label: 'None' },
       ...Array.from(deployments).map((d) => ({
         value: d.id,
         label: d.name,
       })),
     ],
-    initialValue: initialValue,
+    initialValue,
   })
 
   if (isCancel(dp)) {


### PR DESCRIPTION
## Summary

Running \`tanstack create my-app\` without flags silently skipped prompts for framework, deployment, and install — it fell straight through to \`normalizeOptions\` and applied defaults, giving users no chance to configure things that should be interactive.

## Problems

1. **Default interactive mode was never triggered.** The old detection only entered interactive mode on \`--interactive\` or bare \`--add-ons\`. Everything else hit \`normalizeOptions\` which doesn't prompt for anything. Running \`tanstack create my-app\` silently picked React, no toolchain, no deployment, no add-ons.
2. **Deployment was never prompted.** \`showDeploymentOptions\` defaulted to \`false\` on the root \`@tanstack/cli\`, so even if you did reach the interactive path, no deployment prompt appeared.
3. **Framework was never prompted.** The CLI defaulted to React silently when a user had no \`--framework\` flag.
4. **Install was never prompted.** The code only honored \`--no-install\`; there was no "install dependencies now?" prompt.

## Fixes

- Flip the interactive-mode default: interactive when stdin/stdout is a TTY and \`CI\` is unset. Opt out with \`--yes\` / \`--non-interactive\`, or by piping/running in CI (both auto-detected so existing scripts and e2e tests keep working).
- Add a \`selectFramework\` prompt that shows up only when the CLI hosts multiple frameworks and no \`--framework\` flag was passed. Aliases with a fixed \`defaultFramework\` don't get the prompt.
- Add a \`selectInstall\` prompt when \`--no-install\` is not passed.
- Default \`showDeploymentOptions\` to \`true\`. Legacy aliases that set \`forcedDeployment\` (e.g. nitro) now pass that value through to the deployment prompt as the initial selection, so the old default is preserved but users can pick something else.
- Preserve an explicit \`--add-ons <ids>\` array in interactive mode instead of overwriting it with the "prompt me" sentinel.
- Remove the \`'React'\` default from the commander \`--framework\` option so we can distinguish "flag passed" from "default applied."

## Test plan

- [x] Unit tests: \`pnpm --filter @tanstack/cli test\` (84 passed)
- [x] E2E tests: \`pnpm --filter @tanstack/cli test:e2e\` (3 passed, including the CI-mode smoke that runs without \`--yes\`)
- [x] Manual: \`tanstack create my-app\` in a TTY prompts for framework, toolchain, deployment, examples, add-ons, add-on options, env vars, git, install
- [x] Manual: \`tanstack create my-app --yes --no-install --no-git\` skips all prompts, uses defaults
- [x] Manual: \`CI=1 tanstack create my-app --framework react --package-manager pnpm --no-git\` (matches the e2e test invocation) completes without hanging — auto-detected non-interactive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed interactive mode to properly prompt for framework selection when multiple options are available
  * Corrected deployment adapter selection to respect forced deployment defaults
  * Fixed add-ons handling to preserve explicitly provided configurations

* **New Features**
  * Deployment options now display by default in interactive mode
  * Added confirmation prompt for dependency installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->